### PR TITLE
v2.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ var query = myDbContext.Persons.ApplyFiltering("name = John");
 // myDbContext.Persons.Where(p => p.Name == "John");
 ```
 
-### see more examples in the [tests](https://github.com/alirezanet/Gridify/blob/89ff1ce981726c20591b043fee72eb5faa68f458/test/Core.Tests/GridifyExtensionsShould.cs#L22) 
+### see more examples in the [tests](https://github.com/alirezanet/Gridify/blob/6e9c954aae1d5d212412300173229e36e551ec26/test/Gridify.Tests/GridifyExtensionsShould.cs?_pjax=%23js-repo-pjax-container%3Afirst-of-type%2C%20div%5Bitemtype%3D%22http%3A%2F%2Fschema.org%2FSoftwareSourceCode%22%5D%20main%3Afirst-of-type%2C%20%5Bdata-pjax-container%5D%3Afirst-of-type#L22) 
 
 ---
 

--- a/src/Gridify.EntityFramework/Gridify.EntityFramework.csproj
+++ b/src/Gridify.EntityFramework/Gridify.EntityFramework.csproj
@@ -9,7 +9,7 @@
    <PropertyGroup>
       <TargetFramework>netstandard2.0</TargetFramework>
       <PackageId>Gridify.EntityFramework</PackageId>
-      <Version>2.3.1</Version>
+      <Version>2.3.2</Version>
       <Authors>Alireza Sabouri</Authors>
       <Company>TuxTeam</Company>
       <PackageDescription>Gridify (EntityFramework), Easy and optimized way to apply Filtering, Sorting, and Pagination using text-based data.</PackageDescription>

--- a/src/Gridify/Gridify.csproj
+++ b/src/Gridify/Gridify.csproj
@@ -3,7 +3,7 @@
    <PropertyGroup>
       <TargetFramework>netstandard2.0</TargetFramework>
       <PackageId>Gridify</PackageId>
-      <Version>2.3.1</Version>
+      <Version>2.3.2</Version>
       <Authors>Alireza Sabouri</Authors>
       <Company>TuxTeam</Company>
       <PackageDescription>Gridify, Easy and optimized way to apply Filtering, Sorting, and Pagination using text-based data.</PackageDescription>

--- a/src/Gridify/GridifyMapper.cs
+++ b/src/Gridify/GridifyMapper.cs
@@ -135,7 +135,7 @@ namespace Gridify
 
       /// <summary>
       /// Converts current mappings to a comma seperated list of map names.
-      /// eg, filed1,field2,field3 
+      /// eg, field1,field2,field3 
       /// </summary>
       /// <returns>a comma seperated string</returns>
       public override string ToString() => string.Join(",", _mappings.Select(q => q.From));

--- a/src/Gridify/GridifyMapperConfiguration.cs
+++ b/src/Gridify/GridifyMapperConfiguration.cs
@@ -3,8 +3,16 @@ namespace Gridify
    public record GridifyMapperConfiguration
    {
       public bool CaseSensitive { get; set; }
-      public bool AllowNullSearch { get; set; } = true;
       
+      /// <summary>
+      /// This option enables the 'null' keyword in filtering operations
+      /// </summary>
+      public bool AllowNullSearch { get; set; } = true;
+      /// <summary>
+      /// If true, in filtering and ordering operations,
+      /// gridify doesn't return any exceptions when a mapping
+      /// is not defined for the fields
+      /// </summary>
       public bool IgnoreNotMappedFields { get; set; }
    }
 }

--- a/src/Gridify/GridifyMapperConfiguration.cs
+++ b/src/Gridify/GridifyMapperConfiguration.cs
@@ -4,5 +4,7 @@ namespace Gridify
    {
       public bool CaseSensitive { get; set; }
       public bool AllowNullSearch { get; set; } = true;
+      
+      public bool IgnoreNotMappedFields { get; set; }
    }
 }

--- a/test/Gridify.Tests/GridifyExtensionsShould.cs
+++ b/test/Gridify.Tests/GridifyExtensionsShould.cs
@@ -706,7 +706,7 @@ namespace Gridify.Tests
          var gm = new GridifyMapper<TestClass>(configuration => configuration.IgnoreNotMappedFields = true)
             .AddMap("Id", q => q.Id);
       
-         // name=*a filter should be ignored
+         // name orderBy should be ignored
          var actual = _fakeRepository.AsQueryable().ApplyOrdering("name,id", gm).ToList();
          var expected = _fakeRepository.OrderBy(q => q.Id ).ToList();
       

--- a/test/Gridify.Tests/GridifyExtensionsShould.cs
+++ b/test/Gridify.Tests/GridifyExtensionsShould.cs
@@ -97,7 +97,7 @@ namespace Gridify.Tests
       }
 
       [Fact]
-      public void ApplyFiltering_DuplicateFiledName()
+      public void ApplyFiltering_DuplicatefieldName()
       {
          const string gq = "name=John|name=Sara";
          var actual = _fakeRepository.AsQueryable()
@@ -564,6 +564,31 @@ namespace Gridify.Tests
          Assert.True(actual.Any());
       }
 
+
+      [Fact] // issue #34
+      public void ApplyFiltering_UnmappedFields_ShouldThrowException()
+      {
+         var gm = new GridifyMapper<TestClass>()
+            .AddMap("Id", q => q.Id);
+
+         var exp = Assert.Throws<GridifyMapperException>(() => _fakeRepository.AsQueryable().ApplyFiltering("name=John,id>0", gm).ToList());
+         Assert.Equal("Mapping 'name' not found",exp.Message); 
+      }
+      
+      [Fact] // issue #34
+      public void ApplyFiltering_UnmappedFields_ShouldSkipWhenIgnored()
+      {
+         var gm = new GridifyMapper<TestClass>(configuration => configuration.IgnoreNotMappedFields = true)
+            .AddMap("Id", q => q.Id);
+      
+         // name=*a filter should be ignored
+         var actual = _fakeRepository.AsQueryable().ApplyFiltering("name=*a, id>15", gm).ToList();
+         var expected = _fakeRepository.Where(q => q.Id > 15).ToList();
+      
+         Assert.Equal(expected.Count, actual.Count);
+         Assert.Equal(expected, actual);
+         Assert.True(actual.Any());
+      }
 
       #endregion
 

--- a/test/Gridify.Tests/GridifyExtensionsShould.cs
+++ b/test/Gridify.Tests/GridifyExtensionsShould.cs
@@ -457,6 +457,7 @@ namespace Gridify.Tests
          Assert.Equal(expected, actual);
          Assert.True(actual.Any());
       }
+      
 
       [Fact] // issue #27
       public void ApplyFiltering_LessThanBetweenTwoStrings()
@@ -551,6 +552,18 @@ namespace Gridify.Tests
          Assert.Equal(expected, actual);
          Assert.True(actual.Any());
       }
+      
+      [Fact] // issue #33
+      public void ApplyFiltering_WithSpaces()
+      {
+         var actual = _fakeRepository.AsQueryable().ApplyFiltering("name =ali reza").ToList();
+         var expected = _fakeRepository.Where(q => q.Name == "ali reza" ).ToList();
+         
+         Assert.Equal(expected.Count, actual.Count);
+         Assert.Equal(expected, actual);
+         Assert.True(actual.Any());
+      }
+
 
       #endregion
 
@@ -784,7 +797,8 @@ namespace Gridify.Tests
          lst.Add(new TestClass(23, "LI | AM", null));
          lst.Add(new TestClass(24, "(LI,AM)", null, tag: string.Empty));
          lst.Add(new TestClass(25, "Case/i", null, tag: string.Empty));
-         lst.Add(new TestClass(26, "/iCase", null));
+         lst.Add(new TestClass(26, "/iCase", null)); 
+         lst.Add(new TestClass(27, "ali reza", null));
 
          return lst;
       }


### PR DESCRIPTION
- add configuration to allow for filter expressions to exclude unmapped fields instead of throwing an exception
- Change exception when a field is not mapped to `GridifyMapperException` instead of `GridifyFilteringException`