### PR TITLE
Fix comparison with string.Empty in docs

### DIFF
--- a/docs/guide/filtering.md
+++ b/docs/guide/filtering.md
@@ -31,7 +31,7 @@ this is equivalent to the bellow LINQ query:
 ``` csharp
 var x = personsRepo.Where(p =>
              p.Name is null ||
-             p.Name == string.Empty() );
+             p.Name == string.Empty );
 ```
 
 :::


### PR DESCRIPTION
# Description

`string.Empty` is a property.