### PR TITLE
Fix QueryBuilder ordering with custom mapper

### DIFF
--- a/src/Gridify/QueryBuilder.cs
+++ b/src/Gridify/QueryBuilder.cs
@@ -211,7 +211,7 @@ public class QueryBuilder<T> : IQueryBuilder<T>
          query = query.Where(BuildFilteringExpression());
 
       if (!string.IsNullOrEmpty(_orderBy))
-         query = query.ApplyOrdering(_orderBy);
+         query = query.ApplyOrdering(_orderBy, _mapper);
 
       if (_paging.HasValue)
          query = query.Skip(_paging.Value.page * _paging.Value.pageSize).Take(_paging.Value.pageSize);
@@ -235,7 +235,7 @@ public class QueryBuilder<T> : IQueryBuilder<T>
             collection = collection.Where(compiled);
 
          if (!string.IsNullOrEmpty(_orderBy)) // TODO: this also should be compiled
-            collection = collection.AsQueryable().ApplyOrdering(_orderBy);
+            collection = collection.AsQueryable().ApplyOrdering(_orderBy, _mapper);
 
          if (_paging.HasValue)
             collection = collection.Skip(_paging.Value.page * _paging.Value.pageSize).Take(_paging.Value.pageSize);
@@ -294,7 +294,7 @@ public class QueryBuilder<T> : IQueryBuilder<T>
             collection = collection.Where(compiled);
 
          if (!string.IsNullOrEmpty(_orderBy)) // TODO: this also should be compiled
-            collection = collection.AsQueryable().ApplyOrdering(_orderBy);
+            collection = collection.AsQueryable().ApplyOrdering(_orderBy, _mapper);
 
          var result = collection.ToList();
          var count = result.Count();
@@ -314,7 +314,7 @@ public class QueryBuilder<T> : IQueryBuilder<T>
          query = query.Where(BuildFilteringExpression());
 
       if (!string.IsNullOrEmpty(_orderBy))
-         query = query.ApplyOrdering(_orderBy);
+         query = query.ApplyOrdering(_orderBy, _mapper);
 
       var count = query.Count();
 

--- a/src/Gridify/QueryBuilder.cs
+++ b/src/Gridify/QueryBuilder.cs
@@ -251,7 +251,7 @@ public class QueryBuilder<T> : IQueryBuilder<T>
          collection = collection.Where(BuildFilteringExpression().Compile());
 
       if (!string.IsNullOrEmpty(_orderBy))
-         collection = collection.AsQueryable().ApplyOrdering(_orderBy);
+         collection = collection.AsQueryable().ApplyOrdering(_orderBy, _mapper);
 
       if (_paging.HasValue)
          collection = collection.Skip(_paging.Value.page * _paging.Value.pageSize).Take(_paging.Value.pageSize);

--- a/test/Gridify.Tests/QueryBuilderShould.cs
+++ b/test/Gridify.Tests/QueryBuilderShould.cs
@@ -132,6 +132,17 @@ public class QueryBuilderShould
       Assert.Equal(expected, expression.Parameters.First().Name);
    }
 
+   [Fact]
+   public void AddOrderBy_NotMappedColumn_WithCustomMapper_ShouldThrowException()
+   {
+      var builder = new QueryBuilder<TestClass>()
+         .UseCustomMapper(new GridifyMapper<TestClass>())
+         .AddOrderBy("name");
+
+      var buildAction = () => builder.Build(_fakeRepository);
+
+      Assert.Throws<GridifyMapperException>(buildAction);
+   }
 
    #region Validation
 

--- a/test/Gridify.Tests/QueryBuilderShould.cs
+++ b/test/Gridify.Tests/QueryBuilderShould.cs
@@ -139,9 +139,17 @@ public class QueryBuilderShould
          .UseCustomMapper(new GridifyMapper<TestClass>())
          .AddOrderBy("name");
 
-      var buildAction = () => builder.Build(_fakeRepository);
+      var buildIEnumerableAction = () => builder.Build(_fakeRepository);
+      var buildIQueryableAction = () => builder.Build(_fakeRepository.AsQueryable());
+      var buildWithQueryablePagingAction = () => builder.BuildWithQueryablePaging(_fakeRepository.AsQueryable());
+      var buildCompiledAction = () => builder.BuildCompiled()(_fakeRepository);
+      var BuildWithPagingCompiledAction = () => builder.BuildWithPagingCompiled()(_fakeRepository);
 
-      Assert.Throws<GridifyMapperException>(buildAction);
+      Assert.Throws<GridifyMapperException>(buildIEnumerableAction);
+      Assert.Throws<GridifyMapperException>(buildIQueryableAction);
+      Assert.Throws<GridifyMapperException>(buildWithQueryablePagingAction);
+      Assert.Throws<GridifyMapperException>(buildCompiledAction);
+      Assert.Throws<GridifyMapperException>(BuildWithPagingCompiledAction);
    }
 
    #region Validation


### PR DESCRIPTION
# Description

Fix: QueryBuilder doesn't use its own mapper in internal ApplyOrdering calls.

Fixes #95 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have performed a self-review of my code
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
