### PR TITLE
docs(filtering): add `[` to special characters

### DIFF
--- a/docs/guide/filtering.md
+++ b/docs/guide/filtering.md
@@ -63,19 +63,19 @@ this query matches with JOHN - john - John - jOHn ...
 
 ## Escaping
 
-Gridify have five special operators  `, | ( ) /i` to handle complex queries and case-insensitive searches. If you want to use these characters in your query values (after conditional operator), you should add a backslash <code>\ </code> before them. having this regex could be helpfull `([(),|]|\/i)`.
+Gridify have six special operators  `, | ( ) [ /i` to handle complex queries and case-insensitive searches. If you want to use these characters in your query values (after conditional operator), you should add a backslash <code>\ </code> before them. having this regex could be helpfull `([(),|]|\[|\/i)`.
 
 JavaScript escape example:
 
 ``` javascript
-let esc = (v) => v.replace(/([(),|]|\/i)/g, '\\$1')
+let esc = (v) => v.replace(/[(),|]|\[|\/i)/g, '\\$1')
 ```
 
 Csharp escape example:
 
 ``` csharp
 var value = "(test,test2)";
-var esc = Regex.Replace(value, "([(),|]|\/i)", "\\$1" );
+var esc = Regex.Replace(value, "([(),|]|\[|\/i)", "\\$1" );
 // esc = \(test\,test2\)
 ```
 


### PR DESCRIPTION
# Description

Hi 👋🏻,

thanks for providing this awesome library.

When I send a query containing an `[`, I experience the following error.

```
 UNHANDLED EXCEPTION (TraceId=2f9adeb5-7185-4468-92b3-c538884d2834) WAS CAUGHT: bad character input: '/' at 89. expected ']'
   at Gridify.GridifyExtensions.ApplyFiltering[T](IQueryable`1 query, String filter, IGridifyMapper`1 mapper)
         at Gridify.EntityFramework.GridifyExtensions.GridifyQueryableAsync[T](IQueryable`1 query, IGridifyQuery gridifyQuery, IGridifyMapper`1 mapper, CancellationToken token)
         at Gridify.EntityFramework.GridifyExtensions.GridifyAsync[T](IQueryable`1 query, IGridifyQuery gridifyQuery, CancellationToken token, IGridifyMapper`1 mapper)
```

When I escape the `[` with `\` the query works as expected and no error is thrown.

I think `[` is a special character, because it is used to allow [_Indexes_](https://alirezanet.github.io/Gridify/guide/filtering.html#passing-indexes).
That's why it should be escaped.

Therefore, I updated the documentation, accordingly using the following Regex: `/([(),|]|\[|\/i)/g`

I am happy, if you find this contribution useful.

Cheers
Gregor

## Type of change

- [x] Documentation
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
