### PR TITLE
inlcude version 7 of di abstraction package for .net6

### DIFF
--- a/src/Gridify/Gridify.csproj
+++ b/src/Gridify/Gridify.csproj
@@ -35,7 +35,7 @@
    </ItemGroup>
 
    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[6.0.0,7.0.0)" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[6.0.0,8.0.0)" />
    </ItemGroup>
 
    <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">


### PR DESCRIPTION
# Description

Currently there is a version restriction applied for projects running .net6 and use the Microsoft.Extensions.DependencyInjection.Abstractions, currently the libraray must have a version greater or equal to 6.0 but less than 7.0.

As far as I can see updating the version restrictions to include version 7 should not cause any issues.

Please see here for the listed version compatiblity: https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection.Abstractions/7.0.0#supportedframeworks-body-tab

![image](https://github.com/alirezanet/Gridify/assets/31539452/7ebca7fb-264d-4b08-927b-46e5a48d79ab)

## Checklist

- [x] I have performed a self-review of my code
- [x] Existing unit tests pass locally with my changes
