### PR TITLE
Bugfix/escape escape character

### DIFF
--- a/docs/guide/filtering.md
+++ b/docs/guide/filtering.md
@@ -68,14 +68,14 @@ Gridify have five special operators  `, | ( ) /i` to handle complex queries and 
 JavaScript escape example:
 
 ``` javascript
-let esc = (v) => v.replace(/([(),|]|\/i)/g, '\\$1')
+let esc = (v) => v.replace(/([(),|\\]|\/i)/g, '\\$1')
 ```
 
 Csharp escape example:
 
 ``` csharp
 var value = "(test,test2)";
-var esc = Regex.Replace(value, "([(),|]|\/i)", "\\$1" );
+var esc = Regex.Replace(value, "([(),|\\]|\/i)", "\\$1" );
 // esc = \(test\,test2\)
 ```
 

--- a/test/Gridify.Tests/GridifyExtensionsShould.cs
+++ b/test/Gridify.Tests/GridifyExtensionsShould.cs
@@ -1,9 +1,9 @@
 #nullable enable
+using Gridify.Syntax;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using Gridify.Syntax;
 using Xunit;
 
 namespace Gridify.Tests;
@@ -51,6 +51,7 @@ public class GridifyExtensionsShould
       lst.Add(new TestClass(26, "/iCase", null));
       lst.Add(new TestClass(27, "ali reza", null));
       lst.Add(new TestClass(27, "[ali]", null));
+      lst.Add(new TestClass(28, @"Esc/\pe", null));
 
       return lst;
    }
@@ -500,6 +501,19 @@ public class GridifyExtensionsShould
          .ToList();
 
       var expected = _fakeRepository.Where(q => q.Name == "Case/i").ToList();
+      Assert.Equal(expected.Count, actual.Count);
+      Assert.Equal(expected, actual);
+      Assert.True(actual.Any());
+   }
+
+   [Fact]
+   public void ApplyFiltering_EscapeEscapeCharacter()
+   {
+      var actual = _fakeRepository.AsQueryable()
+         .ApplyFiltering(@"Name=Esc/\\pe")
+         .ToList();
+
+      var expected = _fakeRepository.Where(q => q.Name == @"Esc/\pe").ToList();
       Assert.Equal(expected.Count, actual.Count);
       Assert.Equal(expected, actual);
       Assert.True(actual.Any());


### PR DESCRIPTION
# Description

The provided examples for escaping user input in the documentation were missing to handle cases when the string already contains backslashes. I Simply updated the regex to include the backslash character.

I also added a unit test that show cases that gridify already handles escaping of escape characters.

Fixes # (issue)

## Type of change

- [x] Documation fix (non-breaking change which fixes an issue in the provided example code)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
