### PR TITLE
Feature/upgrade dotnet 8

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,9 +64,9 @@ jobs:
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - name: Build
       env:
         HUSKY: 0

--- a/.github/workflows/publush.yml
+++ b/.github/workflows/publush.yml
@@ -13,9 +13,9 @@ jobs:
       steps:
          - uses: actions/checkout@v2
          - name: Setup .NET
-           uses: actions/setup-dotnet@v1
+           uses: actions/setup-dotnet@v3
            with:
-              dotnet-version: 7.0.x
+              dotnet-version: 8.0.x
          - name: Restore dependencies
            run: dotnet restore
          - name: Build

--- a/.github/workflows/pullRequest.yml
+++ b/.github/workflows/pullRequest.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/benchmark/Benchmark.csproj
+++ b/benchmark/Benchmark.csproj
@@ -2,15 +2,15 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <RootNamespace>Benchmarks</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.13.8" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
       <PackageReference Include="Fop" Version="1.0.3" />
       <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.7.0" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.DynamicLinq" Version="7.3.4" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.DynamicLinq" Version="7.3.5" />
       <PackageReference Include="Sieve" Version="2.5.5" />
     </ItemGroup>
 

--- a/src/Gridify.Elasticsearch/Gridify.Elasticsearch.csproj
+++ b/src/Gridify.Elasticsearch/Gridify.Elasticsearch.csproj
@@ -13,7 +13,7 @@
       <IncludeSymbols>true</IncludeSymbols>
       <SymbolPackageFormat>snupkg</SymbolPackageFormat>
       <PackageReadmeFile>README.md</PackageReadmeFile>
-      <TargetFrameworks>net5.0;net6.0;netstandard2.0;netstandard2.1;net7.0</TargetFrameworks>
+      <TargetFrameworks>net6.0;netstandard2.0;netstandard2.1;net7.0;net8.0</TargetFrameworks>
       <LangVersion>default</LangVersion>
       <Nullable>enable</Nullable>
    </PropertyGroup>

--- a/src/Gridify.EntityFramework/Gridify.EntityFramework.csproj
+++ b/src/Gridify.EntityFramework/Gridify.EntityFramework.csproj
@@ -14,7 +14,7 @@
       <IncludeSymbols>true</IncludeSymbols>
       <SymbolPackageFormat>snupkg</SymbolPackageFormat>
       <PackageReadmeFile>README.md</PackageReadmeFile>
-      <TargetFrameworks>net5.0;net6.0;netstandard2.0;netstandard2.1;net7.0</TargetFrameworks>
+      <TargetFrameworks>net6.0;netstandard2.0;netstandard2.1;net7.0;net8.0</TargetFrameworks>
       <LangVersion>default</LangVersion>
       <Nullable>enable</Nullable>
    </PropertyGroup>
@@ -33,9 +33,6 @@
    </ItemGroup>
    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1' ">
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[2.0.0,5.0.0)" />
-   </ItemGroup>
-   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[5.0.0,6.0.0)" />
    </ItemGroup>
    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[6.0.0,7.0.0)" />

--- a/src/Gridify/Gridify.csproj
+++ b/src/Gridify/Gridify.csproj
@@ -18,7 +18,7 @@
       <SymbolPackageFormat>snupkg</SymbolPackageFormat>
       <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
       <PackageReadmeFile>README.md</PackageReadmeFile>
-      <TargetFrameworks>net5.0;net6.0;netstandard2.0;netstandard2.1;net7.0</TargetFrameworks>
+      <TargetFrameworks>net6.0;netstandard2.0;netstandard2.1;net7.0;net8.0</TargetFrameworks>
 
    </PropertyGroup>
 
@@ -36,10 +36,6 @@
 
    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[6.0.0,8.0.0)" />
-   </ItemGroup>
-
-   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0.0,6.0.0)" />
    </ItemGroup>
 
    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">

--- a/test/EntityFrameworkIntegrationTests/EntityFrameworkIntegrationTests.cs.csproj
+++ b/test/EntityFrameworkIntegrationTests/EntityFrameworkIntegrationTests.cs.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
    <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.0" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-      <PackageReference Include="xunit" Version="2.4.2" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-preview-23531-01" />
+      <PackageReference Include="xunit" Version="2.6.1" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/test/EntityFrameworkPostgreSqlIntegrationTests/EntityFrameworkPostgreSqlIntegrationTests.csproj
+++ b/test/EntityFrameworkPostgreSqlIntegrationTests/EntityFrameworkPostgreSqlIntegrationTests.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
    <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.0" />
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-       <PackageReference Include="xunit" Version="2.4.2" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-rc.2" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-preview-23531-01" />
+       <PackageReference Include="xunit" Version="2.6.1" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/test/EntityFrameworkSqlProviderIntegrationTests/EntityFrameworkSqlProviderIntegrationTests.csproj
+++ b/test/EntityFrameworkSqlProviderIntegrationTests/EntityFrameworkSqlProviderIntegrationTests.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
    <PropertyGroup>
-      <TargetFramework>net7.0</TargetFramework>
+      <TargetFramework>net8.0</TargetFramework>
       <RootNamespace>EntityFrameworkIntegrationTests.cs</RootNamespace>
    </PropertyGroup>
 
    <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.0" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-      <PackageReference Include="xunit" Version="2.4.2" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+      <PackageReference Include="xunit" Version="2.6.1" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/test/Gridify.Elasticsearch.Tests/Gridify.Elasticsearch.Tests.csproj
+++ b/test/Gridify.Elasticsearch.Tests/Gridify.Elasticsearch.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
    <PropertyGroup>
-      <TargetFramework>net7.0</TargetFramework>
+      <TargetFramework>net8.0</TargetFramework>
       <IsPackable>false</IsPackable>
       <LangVersion>latest</LangVersion>
       <Nullable>enable</Nullable>
@@ -9,9 +9,9 @@
 
    <ItemGroup>
       <PackageReference Include="AutoBogus" Version="2.13.1" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-      <PackageReference Include="xunit" Version="2.4.2" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+      <PackageReference Include="xunit" Version="2.6.1" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
          <PrivateAssets>all</PrivateAssets>
          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/test/Gridify.Tests/Gridify.Tests.csproj
+++ b/test/Gridify.Tests/Gridify.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
    <PropertyGroup>
-      <TargetFramework>net7.0</TargetFramework>
+      <TargetFramework>net8.0</TargetFramework>
       <IsPackable>false</IsPackable>
       <LangVersion>latest</LangVersion>
       <Nullable>enable</Nullable>
@@ -9,9 +9,9 @@
 
    <ItemGroup>
       <PackageReference Include="AutoBogus" Version="2.13.1" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-      <PackageReference Include="xunit" Version="2.4.2" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+      <PackageReference Include="xunit" Version="2.6.1" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>


### PR DESCRIPTION
# Description

NET 8 Support

Closes #138 

- Update Gridify to target .NET8
- Drop NET5 Support 
