### PR TITLE
Performance improvement

### DIFF
--- a/benchmark/NativeLinqComparisionBenchmark.cs
+++ b/benchmark/NativeLinqComparisionBenchmark.cs
@@ -1,0 +1,52 @@
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Order;
+using Gridify;
+using Gridify.Tests;
+
+namespace Benchmarks;
+
+[MemoryDiagnoser]
+[RPlotExporter]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class NativeLinqComparisionBenchmark
+{
+   private static readonly Consumer Consumer = new();
+   private TestClass[] _data;
+   private GridifyMapper<TestClass> _gm;
+
+   private IQueryable<TestClass> Ds => _data.AsQueryable();
+
+   [GlobalSetup]
+   public void Setup()
+   {
+      _data = LibraryComparisionFilteringBenchmark.GetSampleData().ToArray();
+      _gm = new GridifyMapper<TestClass>(true);
+   }
+
+
+   [Benchmark(Baseline = true)]
+   public void Native_LINQ()
+   {
+      Ds.Where(q => q.Name.Contains('a')).Consume(Consumer);
+      Ds.Where(q => q.Id > 5).Consume(Consumer);
+      Ds.Where(q => q.Name == "Ali").Consume(Consumer);
+   }
+
+   [Benchmark]
+   public void Gridify()
+   {
+      Ds.ApplyFiltering("Name=*a", _gm).Consume(Consumer);
+      Ds.ApplyFiltering("Id>5", _gm).Consume(Consumer);
+      Ds.ApplyFiltering("Name=Ali", _gm).Consume(Consumer);
+   }
+
+   [Benchmark]
+   public void Gridify_WithoutMapper()
+   {
+      Ds.ApplyFiltering("Name=*a").Consume(Consumer);
+      Ds.ApplyFiltering("Id>5").Consume(Consumer);
+      Ds.ApplyFiltering("Name=Ali").Consume(Consumer);
+   }
+}

--- a/benchmark/NativeLinqComparisonBenchmark.cs
+++ b/benchmark/NativeLinqComparisonBenchmark.cs
@@ -10,7 +10,7 @@ namespace Benchmarks;
 [MemoryDiagnoser]
 [RPlotExporter]
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
-public class NativeLinqComparisionBenchmark
+public class NativeLinqComparisonBenchmark
 {
    private static readonly Consumer Consumer = new();
    private TestClass[] _data;

--- a/benchmark/Program.cs
+++ b/benchmark/Program.cs
@@ -7,7 +7,8 @@ public class Program
 {
    private static void Main()
    {
-      BenchmarkRunner.Run<LibraryComparisionFilteringBenchmark>();
+      // BenchmarkRunner.Run<LibraryComparisionFilteringBenchmark>();
+      BenchmarkRunner.Run<NativeLinqComparisionBenchmark>();
       // BenchmarkRunner.Run<LibraryComparisionFilteringBenchmark2>();
       // BenchmarkRunner.Run<GridifyMapperUsages>();
       // BenchmarkRunner.Run<QueryBuilderBuildBenchmark>();

--- a/docs/.vitepress/configs/version.ts
+++ b/docs/.vitepress/configs/version.ts
@@ -1,1 +1,1 @@
-export const version: string = '2.15.0-preview1'
+export const version: string = '2.15.0-preview2'

--- a/src/Gridify.Elasticsearch/ElasticsearchQueryBuilder.cs
+++ b/src/Gridify.Elasticsearch/ElasticsearchQueryBuilder.cs
@@ -13,7 +13,7 @@ internal class ElasticsearchQueryBuilder<T>(IGridifyMapper<T> mapper) : BaseQuer
    private readonly IGridifyMapper<T> _mapper = mapper;
 
    protected override Query BuildNestedQuery(
-      Expression body, IGMap<T> gMap, ValueExpressionSyntax value, SyntaxNode op)
+      Expression body, IGMap<T> gMap, ValueExpressionSyntax value, ISyntaxNode op)
    {
       throw new NotSupportedException();
    }
@@ -40,7 +40,7 @@ internal class ElasticsearchQueryBuilder<T>(IGridifyMapper<T> mapper) : BaseQuer
       Expression body,
       ParameterExpression parameter,
       object? value,
-      SyntaxNode op,
+      ISyntaxNode op,
       ValueExpressionSyntax valueExpression)
    {
       if (valueExpression.IsCaseInsensitive)

--- a/src/Gridify.Elasticsearch/Gridify.Elasticsearch.csproj
+++ b/src/Gridify.Elasticsearch/Gridify.Elasticsearch.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
    <PropertyGroup>
       <PackageId>Gridify.Elasticsearch</PackageId>
-      <Version>2.15.0-preview1</Version>
+      <Version>2.15.0-preview2</Version>
       <Authors>Alireza Sabouri; Dzmitry Koush</Authors>
       <PackageDescription>Gridify (Elasticsearch), Easy way to apply Filtering, Sorting, and Pagination using text-based data.</PackageDescription>
       <RepositoryUrl>https://github.com/alirezanet/Gridify</RepositoryUrl>

--- a/src/Gridify.EntityFramework/Gridify.EntityFramework.csproj
+++ b/src/Gridify.EntityFramework/Gridify.EntityFramework.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
    <PropertyGroup>
       <PackageId>Gridify.EntityFramework</PackageId>
-      <Version>2.15.0-preview1</Version>
+      <Version>2.15.0-preview2</Version>
       <Authors>Alireza Sabouri</Authors>
       <Company>TuxTeam</Company>
       <PackageDescription>Gridify (EntityFramework), Easy and optimized way to apply Filtering, Sorting, and Pagination using text-based data.</PackageDescription>

--- a/src/Gridify/Gridify.csproj
+++ b/src/Gridify/Gridify.csproj
@@ -2,7 +2,7 @@
 
    <PropertyGroup>
       <PackageId>Gridify</PackageId>
-      <Version>2.15.0-preview1</Version>
+      <Version>2.15.0-preview2</Version>
       <Authors>Alireza Sabouri</Authors>
       <Company>TuxTeam</Company>
       <PackageDescription>Gridify, Easy and optimized way to apply Filtering, Sorting, and Pagination using text-based data.</PackageDescription>

--- a/src/Gridify/GridifyExtensions.cs
+++ b/src/Gridify/GridifyExtensions.cs
@@ -178,24 +178,24 @@ public static partial class GridifyExtensions
 
       mapper = new GridifyMapper<T>();
 
-      var fields = syntaxTree.Root.Descendants()
-         .Where(q => q.Kind == SyntaxKind.FieldExpression)
-         .Cast<FieldExpressionSyntax>()
-         .Distinct(new FieldExpressionComparer());
+      var root = syntaxTree.Root;
+      var fields = root.Descendants()
+          .OfType<FieldExpressionSyntax>()
+          .Distinct(new FieldExpressionComparer());
 
-      foreach (var field in fields)
-         try
-         {
-            mapper.AddMap(field.FieldToken.Text);
-         }
-         catch (Exception)
-         {
-            if (!mapper.Configuration.IgnoreNotMappedFields)
-               throw new GridifyMapperException($"Property '{field.FieldToken.Text}' not found.");
-         }
+      try
+      {
+         foreach (var field in fields) mapper.AddMap(field.FieldToken.Text);
+      }
+      catch (Exception)
+      {
+         if (!mapper.Configuration.IgnoreNotMappedFields)
+            throw;
+      }
 
       return mapper;
    }
+
 
    private static IEnumerable<ISyntaxNode> Descendants(this ISyntaxNode root)
    {

--- a/src/Gridify/GridifyExtensions.cs
+++ b/src/Gridify/GridifyExtensions.cs
@@ -197,9 +197,9 @@ public static partial class GridifyExtensions
       return mapper;
    }
 
-   private static IEnumerable<SyntaxNode> Descendants(this SyntaxNode root)
+   private static IEnumerable<ISyntaxNode> Descendants(this ISyntaxNode root)
    {
-      var nodes = new Stack<SyntaxNode>(new[] { root });
+      var nodes = new Stack<ISyntaxNode>(new[] { root });
       while (nodes.Any())
       {
          var node = nodes.Pop();

--- a/src/Gridify/GridifyMapper.cs
+++ b/src/Gridify/GridifyMapper.cs
@@ -1,9 +1,8 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
+using Gridify.Syntax;
 
 namespace Gridify;
 
@@ -48,10 +47,7 @@ public class GridifyMapper<T> : IGridifyMapper<T>
       Expression<Func<T, object>> to;
       try
       {
-         var expression = CreateExpression(from);
-         if (expression is null)
-            return this;
-         to = expression;
+         to = CreateExpression(from); ;
       }
       catch (Exception)
       {
@@ -85,7 +81,7 @@ public class GridifyMapper<T> : IGridifyMapper<T>
          var fullName = string.IsNullOrEmpty(prefix) ? propertyName : $"{prefix}.{propertyName}";
 
          // Skip classes if nestingLevel is exceeded
-         if (item.PropertyType.IsClass && item.PropertyType != typeof(string))
+         if (item.PropertyType.IsClass && item.PropertyType != typeof(string) && !item.PropertyType.IsSimpleTypeCollection(out _))
          {
             if (currentDepth >= maxNestingDepth)
             {
@@ -214,14 +210,14 @@ public class GridifyMapper<T> : IGridifyMapper<T>
    /// <returns>a comma seperated string</returns>
    public override string ToString() => string.Join(",", _mappings.Select(q => q.From));
 
-   internal static Expression<Func<T, object>>? CreateExpression(string from) // TODO: handle possible nulls
+   internal static Expression<Func<T, object>> CreateExpression(string from) // TODO: handle possible nulls
    {
       // Param_x =>
       var parameter = Expression.Parameter(typeof(T), "__" + typeof(T).Name);
       // Param_x.Name, Param_x.yyy.zz.xx
       var mapProperty = from.Split('.').Aggregate<string, Expression>(parameter, Expression.Property);
 
-      if (!IsListOrArrayOfPrimitivesOrString(mapProperty.Type, out var genericType))
+      if (!mapProperty.Type.IsSimpleTypeCollection(out var genericType))
       {
          // (object)Param_x.Name
          var convertedExpression = Expression.Convert(mapProperty, typeof(object));
@@ -229,9 +225,7 @@ public class GridifyMapper<T> : IGridifyMapper<T>
          return Expression.Lambda<Func<T, object>>(convertedExpression, parameter);
       }
 
-      var selectMethod = GetSelectMethod([genericType!, genericType!]);
-      if (selectMethod is null)
-         return null;
+      var selectMethod = genericType!.GetSimpleTypeSelectMethod();
       var predicateParameter = Expression.Parameter(genericType!);
       var predicate = Expression.Lambda(predicateParameter, predicateParameter);
       //  Param_x.Name.Select(fc => fc)
@@ -239,39 +233,5 @@ public class GridifyMapper<T> : IGridifyMapper<T>
       return Expression.Lambda<Func<T, object>>(body, parameter);
    }
 
-   private static MethodInfo? GetSelectMethod(Type[] type)
-   {
-      return typeof(Enumerable).GetMethods().First(m => m.Name == "Select").MakeGenericMethod(type);
-   }
-
-   private static bool IsListOrArrayOfPrimitivesOrString(Type type, out Type? itemType)
-   {
-      itemType = null;
-      if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(List<>))
-      {
-         var arguments = type.GetGenericArguments();
-         if (arguments.Length != 1 || !IsPrimitiveOrKnownType(arguments[0])) return false;
-
-         itemType = arguments[0];
-         return true;
-      }
-      if (!type.IsArray) return false;
-
-      var elementType = type.GetElementType();
-      if (elementType == null || !IsPrimitiveOrKnownType(elementType)) return false;
-      itemType = elementType;
-      return true;
-   }
-
-   private static bool IsPrimitiveOrKnownType(Type type)
-   {
-      // Primitive types in C# include: int, float, double, char, bool, etc.
-      // Also consider the known primitive types and string explicitly
-      return type.IsPrimitive ||
-             (type == typeof(string)) ||
-             (type == typeof(decimal)) ||
-             (type == typeof(DateTime)) ||
-             (type == typeof(Guid));
-   }
 
 }

--- a/src/Gridify/GridifyMapper.cs
+++ b/src/Gridify/GridifyMapper.cs
@@ -210,7 +210,7 @@ public class GridifyMapper<T> : IGridifyMapper<T>
    /// <returns>a comma seperated string</returns>
    public override string ToString() => string.Join(",", _mappings.Select(q => q.From));
 
-   internal static Expression<Func<T, object>> CreateExpression(string from) // TODO: handle possible nulls
+   internal static Expression<Func<T, object>> CreateExpression(string from)
    {
       // Param_x =>
       var parameter = Expression.Parameter(typeof(T), "__" + typeof(T).Name);

--- a/src/Gridify/QueryBuilders/BaseQueryBuilder.cs
+++ b/src/Gridify/QueryBuilders/BaseQueryBuilder.cs
@@ -16,7 +16,7 @@ internal abstract class BaseQueryBuilder<TQuery, T>(IGridifyMapper<T> mapper)
    }
 
    protected abstract TQuery? BuildNestedQuery(
-      Expression body, IGMap<T> gMap, ValueExpressionSyntax value, SyntaxNode op);
+      Expression body, IGMap<T> gMap, ValueExpressionSyntax value, ISyntaxNode op);
 
    protected abstract TQuery BuildAlwaysTrueQuery();
 
@@ -31,7 +31,7 @@ internal abstract class BaseQueryBuilder<TQuery, T>(IGridifyMapper<T> mapper)
       Expression body,
       ParameterExpression parameter,
       object? value,
-      SyntaxNode op,
+      ISyntaxNode op,
       ValueExpressionSyntax valueExpression);
 
    protected abstract TQuery CombineWithAndOperator(TQuery left, TQuery right);
@@ -157,7 +157,7 @@ internal abstract class BaseQueryBuilder<TQuery, T>(IGridifyMapper<T> mapper)
       Expression body,
       ParameterExpression parameter,
       ValueExpressionSyntax valueExpression,
-      SyntaxNode op,
+      ISyntaxNode op,
       Func<string, object>? convertor)
    {
       // Remove the boxing for value types

--- a/src/Gridify/QueryBuilders/LinqQueryBuilder.cs
+++ b/src/Gridify/QueryBuilders/LinqQueryBuilder.cs
@@ -10,7 +10,7 @@ namespace Gridify.QueryBuilders;
 internal class LinqQueryBuilder<T>(IGridifyMapper<T> mapper) : BaseQueryBuilder<Expression<Func<T, bool>>, T>(mapper)
 {
    protected override Expression<Func<T, bool>>? BuildNestedQuery(
-      Expression body, IGMap<T> gMap, ValueExpressionSyntax value, SyntaxNode op)
+      Expression body, IGMap<T> gMap, ValueExpressionSyntax value, ISyntaxNode op)
    {
       while (true)
          switch (body)
@@ -105,7 +105,7 @@ internal class LinqQueryBuilder<T>(IGridifyMapper<T> mapper) : BaseQueryBuilder<
       Expression body,
       ParameterExpression parameter,
       object? value,
-      SyntaxNode op,
+      ISyntaxNode op,
       ValueExpressionSyntax valueExpression)
    {
       Expression be;
@@ -229,7 +229,7 @@ internal class LinqQueryBuilder<T>(IGridifyMapper<T> mapper) : BaseQueryBuilder<
 
             break;
          case SyntaxKind.CustomOperator:
-            var token = op as SyntaxToken;
+            var token = (SyntaxToken)op;
             var customOperator = GridifyGlobalConfiguration.CustomOperators.Operators.First(q => q.GetOperator() == token!.Text);
             var customExp = customOperator.OperatorHandler();
 
@@ -257,7 +257,7 @@ internal class LinqQueryBuilder<T>(IGridifyMapper<T> mapper) : BaseQueryBuilder<
       return left.Or(right);
    }
 
-   private Expression<Func<T, bool>>? GenerateNestedExpression(Expression body, IGMap<T> gMap, ValueExpressionSyntax value, SyntaxNode op)
+   private Expression<Func<T, bool>>? GenerateNestedExpression(Expression body, IGMap<T> gMap, ValueExpressionSyntax value, ISyntaxNode op)
    {
       while (true)
          switch (body)

--- a/src/Gridify/Syntax/BinaryExpressionSyntax.cs
+++ b/src/Gridify/Syntax/BinaryExpressionSyntax.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Gridify.Syntax;
 
@@ -17,7 +17,7 @@ internal sealed class BinaryExpressionSyntax : ExpressionSyntax
 
    public override SyntaxKind Kind => SyntaxKind.BinaryExpression;
 
-   public override IEnumerable<SyntaxNode> GetChildren()
+   public override IEnumerable<ISyntaxNode> GetChildren()
    {
       yield return Left;
       yield return OperatorToken;

--- a/src/Gridify/Syntax/ExpressionSyntax.cs
+++ b/src/Gridify/Syntax/ExpressionSyntax.cs
@@ -1,5 +1,9 @@
-﻿namespace Gridify.Syntax;
+using System.Collections.Generic;
 
-public abstract class ExpressionSyntax : SyntaxNode
+namespace Gridify.Syntax;
+
+public abstract class ExpressionSyntax : ISyntaxNode
 {
+   public abstract SyntaxKind Kind { get; }
+   public abstract IEnumerable<ISyntaxNode> GetChildren();
 }

--- a/src/Gridify/Syntax/FieldExpressionSyntax.cs
+++ b/src/Gridify/Syntax/FieldExpressionSyntax.cs
@@ -12,7 +12,7 @@ internal sealed class FieldExpressionSyntax : ExpressionSyntax
 
    public override SyntaxKind Kind => SyntaxKind.FieldExpression;
 
-   public override IEnumerable<SyntaxNode> GetChildren()
+   public override IEnumerable<ISyntaxNode> GetChildren()
    {
       yield return FieldToken;
    }

--- a/src/Gridify/Syntax/ISyntaxNode.cs
+++ b/src/Gridify/Syntax/ISyntaxNode.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Gridify.Syntax;
+
+public interface ISyntaxNode
+{
+   public SyntaxKind Kind { get; }
+   public IEnumerable<ISyntaxNode> GetChildren();
+}

--- a/src/Gridify/Syntax/Lexer.cs
+++ b/src/Gridify/Syntax/Lexer.cs
@@ -192,7 +192,7 @@ internal ref struct Lexer(string text, IEnumerable<IGridifyOperator> customOpera
       return false;
    }
 
-   private bool TryToReadTheValue(out SyntaxToken? valueToken)
+   private bool TryToReadTheValue(out SyntaxToken valueToken)
    {
       if (_waitingForValue)
       {
@@ -249,7 +249,7 @@ internal ref struct Lexer(string text, IEnumerable<IGridifyOperator> customOpera
          }
       }
 
-      valueToken = null;
+      valueToken = new SyntaxToken();
       return false;
    }
 

--- a/src/Gridify/Syntax/OperatorManager.cs
+++ b/src/Gridify/Syntax/OperatorManager.cs
@@ -1,25 +1,26 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 
 namespace Gridify.Syntax;
 
 public class OperatorManager
 {
-   private readonly ConcurrentDictionary<string, IGridifyOperator> _operators = new();
-   internal IEnumerable<IGridifyOperator> Operators => _operators.Values;
+   private ConcurrentDictionary<string, IGridifyOperator>? _operators;
+   internal IEnumerable<IGridifyOperator> Operators => _operators?.Values ?? Enumerable.Empty<IGridifyOperator>();
 
    public void Register<TOperator>() where TOperator : IGridifyOperator
    {
-      var gridifyOperator = (IGridifyOperator) Activator.CreateInstance(typeof(TOperator))!;
+      var gridifyOperator = (IGridifyOperator)Activator.CreateInstance(typeof(TOperator))!;
       Register(gridifyOperator);
    }
 
    public void Register(IGridifyOperator gridifyOperator)
    {
       Validate(gridifyOperator.GetOperator());
-
+      _operators ??= new();
       _operators.Add(gridifyOperator);
    }
 
@@ -28,15 +29,16 @@ public class OperatorManager
       Validate(@operator);
 
       var customOperator = new GridifyOperator(@operator, handler);
+      _operators ??= new();
       _operators.Add(customOperator);
    }
    public void Remove<TOperator>() where TOperator : IGridifyOperator
    {
-      var gridifyOperator = (IGridifyOperator) Activator.CreateInstance(typeof(TOperator))!;
+      var gridifyOperator = (IGridifyOperator)Activator.CreateInstance(typeof(TOperator))!;
       Remove(gridifyOperator.GetOperator());
    }
 
-   public void Remove(string @operator) => _operators.Remove(@operator);
+   public void Remove(string @operator) => _operators?.Remove(@operator);
 
    private static void Validate(string @operator)
    {

--- a/src/Gridify/Syntax/ParenthesizedExpressionSyntax.cs
+++ b/src/Gridify/Syntax/ParenthesizedExpressionSyntax.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Gridify.Syntax;
 
@@ -7,15 +7,15 @@ internal sealed class ParenthesizedExpressionSyntax : ExpressionSyntax
    public SyntaxToken OpenParenthesisToken { get; }
    public ExpressionSyntax Expression { get; }
    public SyntaxToken CloseParenthesisToken { get; }
-   public override SyntaxKind Kind  => SyntaxKind.ParenthesizedExpression;
+   public override SyntaxKind Kind => SyntaxKind.ParenthesizedExpression;
 
-   public ParenthesizedExpressionSyntax(SyntaxToken openParenthesisToken,ExpressionSyntax expression,SyntaxToken closeParenthesisToken)
+   public ParenthesizedExpressionSyntax(SyntaxToken openParenthesisToken, ExpressionSyntax expression, SyntaxToken closeParenthesisToken)
    {
       OpenParenthesisToken = openParenthesisToken;
       Expression = expression;
       CloseParenthesisToken = closeParenthesisToken;
    }
-   public override IEnumerable<SyntaxNode> GetChildren()
+   public override IEnumerable<ISyntaxNode> GetChildren()
    {
       yield return OpenParenthesisToken;
       yield return Expression;

--- a/src/Gridify/Syntax/Parser.cs
+++ b/src/Gridify/Syntax/Parser.cs
@@ -55,7 +55,7 @@ internal struct Parser
       return new SyntaxTree(_diagnostics ?? Enumerable.Empty<string>(), expression, end);
    }
 
-   private SyntaxKind GetExpectation(SyntaxKind kind)
+   private static SyntaxKind GetExpectation(SyntaxKind kind)
    {
       switch (kind)
       {
@@ -103,7 +103,7 @@ internal struct Parser
       return left;
    }
 
-   private ExpressionSyntax ParseValueExpression()
+   private ValueExpressionSyntax ParseValueExpression()
    {
       // field=
       if (Current.Kind != SyntaxKind.ValueToken)
@@ -140,7 +140,7 @@ internal struct Parser
 
       expectation ??= kind;
 
-      if (_diagnostics != null && !_diagnostics.Any(q => q.StartsWith("Unexpected token")))
+      if (_diagnostics is null || !_diagnostics.Any(q => q.StartsWith("Unexpected token")))
          AddDiagnostics($"Unexpected token <{Current.Kind}> at index {Current.Position}, expected <{expectation}>");
 
       return new SyntaxToken(kind, Current.Position, Current.Text);
@@ -156,7 +156,7 @@ internal struct Parser
       return new ParenthesizedExpressionSyntax(left, expression, right);
    }
 
-   private ExpressionSyntax ParseFieldExpression()
+   private FieldExpressionSyntax ParseFieldExpression()
    {
       var fieldToken = Match(SyntaxKind.FieldToken);
 

--- a/src/Gridify/Syntax/SimpleTypeHelper.cs
+++ b/src/Gridify/Syntax/SimpleTypeHelper.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Gridify.Syntax;
+
+internal static class SimpleTypeHelper
+{
+   internal static bool IsSimpleTypeCollection(this Type type, out Type? itemType)
+   {
+      itemType = null;
+      if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(List<>))
+      {
+         var arguments = type.GetGenericArguments();
+         if (arguments.Length != 1 || !IsSimpleType(arguments[0])) return false;
+
+         itemType = arguments[0];
+         return true;
+      }
+      if (!type.IsArray) return false;
+
+      var elementType = type.GetElementType();
+      if (elementType == null || !IsSimpleType(elementType)) return false;
+      itemType = elementType;
+      return true;
+   }
+
+   internal static bool IsSimpleType(this Type type)
+   {
+      // Primitive types in C# include: int, float, double, char, bool, etc.
+      // Also consider the known primitive types and string explicitly
+      return type.IsPrimitive || type.IsValueType ||
+             (type == typeof(string)) ||
+             (type == typeof(decimal)) ||
+             (type == typeof(DateTime)) ||
+             (type == typeof(Guid));
+   }
+
+   public static MethodInfo GetSimpleTypeSelectMethod(this Type type)
+   {
+      return typeof(Enumerable).GetMethods().First(m => m.Name == "Select").MakeGenericMethod([type, type]);
+   }
+}

--- a/src/Gridify/Syntax/SyntaxNode.cs
+++ b/src/Gridify/Syntax/SyntaxNode.cs
@@ -1,9 +1,0 @@
-﻿using System.Collections.Generic;
-
-namespace Gridify.Syntax;
-
-public abstract class SyntaxNode
-{
-   public abstract SyntaxKind Kind { get; }
-   public abstract IEnumerable<SyntaxNode> GetChildren();
-}

--- a/src/Gridify/Syntax/SyntaxToken.cs
+++ b/src/Gridify/Syntax/SyntaxToken.cs
@@ -3,26 +3,18 @@ using System.Linq;
 
 namespace Gridify.Syntax;
 
-public class SyntaxToken : SyntaxNode
+public struct SyntaxToken(SyntaxKind kind, int position, string text) : ISyntaxNode
 {
-   public override SyntaxKind Kind { get; }
-   public int Position { get; }
-   public string Text { get; }
+   public int Position { get; } = position;
+   public string Text { get; } = text;
+   public SyntaxKind Kind { get; } = kind;
 
-   public override IEnumerable<SyntaxNode> GetChildren()
+   public IEnumerable<ISyntaxNode> GetChildren()
    {
-      return Enumerable.Empty<SyntaxNode>();
+      return Enumerable.Empty<ISyntaxNode>();
    }
 
-   public SyntaxToken(SyntaxKind kind, int position, string text)
+   public SyntaxToken() : this(SyntaxKind.End, 0, string.Empty)
    {
-      Kind = kind;
-      Position = position;
-      Text = text;
-   }
-
-   public SyntaxToken()
-   {
-      Text = string.Empty;
    }
 }

--- a/src/Gridify/Syntax/ValueExpressionSyntax.cs
+++ b/src/Gridify/Syntax/ValueExpressionSyntax.cs
@@ -1,10 +1,10 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Gridify.Syntax;
 
 internal sealed class ValueExpressionSyntax : ExpressionSyntax
 {
-   public ValueExpressionSyntax(SyntaxToken valueToken,bool isCaseInsensitive, bool isNullOrDefault)
+   public ValueExpressionSyntax(SyntaxToken valueToken, bool isCaseInsensitive, bool isNullOrDefault)
    {
       ValueToken = valueToken;
       IsCaseInsensitive = isCaseInsensitive;
@@ -13,7 +13,7 @@ internal sealed class ValueExpressionSyntax : ExpressionSyntax
 
    public override SyntaxKind Kind => SyntaxKind.ValueExpression;
 
-   public override IEnumerable<SyntaxNode> GetChildren()
+   public override IEnumerable<ISyntaxNode> GetChildren()
    {
       yield return ValueToken;
    }

--- a/test/Gridify.Tests/IssueTests/Issue168Tests.cs
+++ b/test/Gridify.Tests/IssueTests/Issue168Tests.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Xunit;
+
+namespace Gridify.Tests.IssueTests;
+
+public class Issue168Tests
+{
+   [Fact]
+   [SuppressMessage("ReSharper", "InconsistentNaming")]
+   public void IssueStory()
+   {
+      // arrange
+      var dataSource = new List<Artist>()
+      {
+         new() {FavouriteColors = ["Green", "Blue"]},
+         new() {FavouriteColors = ["White", "Yellow"]},
+      }.AsQueryable();
+
+      var mapper = new GridifyMapper<Artist>()
+         .AddMap("FavouriteColors", w => w.FavouriteColors.Select(Param_0 => Param_0));
+      var expected = dataSource.ApplyFiltering("FavouriteColors=Red|FavouriteColors=Blue", mapper);
+
+      // act
+      var actual = dataSource.ApplyFiltering("FavouriteColors=Red|FavouriteColors=Blue");
+
+      // assert
+      Assert.Equal(expected.ToString(), actual.ToString());
+      var actualList = actual.ToList();
+      Assert.Equal(expected.ToList(), actualList);
+      Assert.Single(actualList);
+   }
+   private class Artist
+   {
+      public List<string> FavouriteColors { get; set; } = [];
+   }
+}

--- a/test/Gridify.Tests/IssueTests/Issue168Tests.cs
+++ b/test/Gridify.Tests/IssueTests/Issue168Tests.cs
@@ -5,25 +5,26 @@ using Xunit;
 
 namespace Gridify.Tests.IssueTests;
 
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+[SuppressMessage("ReSharper", "ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract")]
 public class Issue168Tests
 {
    [Fact]
-   [SuppressMessage("ReSharper", "InconsistentNaming")]
-   public void IssueStory()
+   public void ApplyFiltering_WithoutMapper_ShouldGenerateMappingsForListOfStrings()
    {
       // arrange
-      var dataSource = new List<Artist>()
+      var dataSource = new List<Test>()
       {
-         new() {FavouriteColors = ["Green", "Blue"]},
-         new() {FavouriteColors = ["White", "Yellow"]},
+         new() {FavouriteColorList = ["Green", "Blue"]},
+         new() {FavouriteColorList = ["White", "Yellow"]},
       }.AsQueryable();
 
-      var mapper = new GridifyMapper<Artist>()
-         .AddMap("FavouriteColors", w => w.FavouriteColors.Select(Param_0 => Param_0));
-      var expected = dataSource.ApplyFiltering("FavouriteColors=Red|FavouriteColors=Blue", mapper);
+      var mapper = new GridifyMapper<Test>()
+         .AddMap("FavouriteColorList", w => w.FavouriteColorList.Select(Param_0 => Param_0));
+      var expected = dataSource.ApplyFiltering("FavouriteColorList=Red|FavouriteColorList=Blue", mapper);
 
       // act
-      var actual = dataSource.ApplyFiltering("FavouriteColors=Red|FavouriteColors=Blue");
+      var actual = dataSource.ApplyFiltering("FavouriteColorList=Red|FavouriteColorList=Blue");
 
       // assert
       Assert.Equal(expected.ToString(), actual.ToString());
@@ -31,8 +32,126 @@ public class Issue168Tests
       Assert.Equal(expected.ToList(), actualList);
       Assert.Single(actualList);
    }
-   private class Artist
+
+   [Fact]
+   public void GenerateMappings_ShouldGenerateMappingsForSimpleTypes()
    {
-      public List<string> FavouriteColors { get; set; } = [];
+      var gm = new GridifyMapper<Test>()
+         .GenerateMappings();
+
+      Assert.Equal(typeof(Test).GetProperties().Length, gm.GetCurrentMaps().Count());
+   }
+
+   [Fact]
+   public void ApplyFiltering_WithoutMapper_ShouldGenerateMappingsForArrayOfStrings()
+   {
+      // arrange
+      var dataSource = new List<Test>()
+      {
+         new() {FavouriteColorsArray = ["Green", "Blue"]},
+         new() {FavouriteColorsArray = ["White", "Yellow"]},
+      }.AsQueryable();
+
+      var mapper = new GridifyMapper<Test>()
+         .AddMap("FavouriteColorsArray", w => w.FavouriteColorsArray.Select(Param_0 => Param_0));
+      var expected = dataSource.ApplyFiltering("FavouriteColorsArray=Red|FavouriteColorsArray=Blue", mapper);
+
+      // act
+      var actual = dataSource.ApplyFiltering("FavouriteColorsArray=Red|FavouriteColorsArray=Blue");
+
+      // assert
+      Assert.Equal(expected.ToString(), actual.ToString());
+      var actualList = actual.ToList();
+      Assert.Equal(expected.ToList(), actualList);
+      Assert.Single(actualList);
+   }
+
+   [Fact]
+   public void ApplyFiltering_WithoutMapper_ShouldGenerateTheCorrectQuery()
+   {
+      // arrange
+      var dataSource = new List<Test>()
+      {
+         new() {NumbersArray = [1, 2]},
+         new() {NumbersArray = [3, 4]},
+      }.AsQueryable();
+
+      var expected = dataSource.Where(__Test => __Test.NumbersArray != null && __Test.NumbersArray.Contains(2));
+
+      // act
+      var actual = dataSource.ApplyFiltering("NumbersArray=2");
+
+      // assert
+      Assert.Equal(expected.ToString(), actual.ToString());
+      var actualList = actual.ToList();
+      Assert.Equal(expected.ToList(), actualList);
+      Assert.Single(actualList);
+      GridifyGlobalConfiguration.DisableNullChecks = false;
+   }
+
+   [Fact]
+   public void ApplyFiltering_WithoutMapperWithMultipleConditions_ShouldGenerateTheCorrectQuery()
+   {
+      // arrange
+      var dataSource = new List<Test>()
+      {
+         new() {NumbersArray = [1, 2]},
+         new() {NumbersArray = [3, 4]},
+      }.AsQueryable();
+
+      var expected = dataSource.Where(__Test =>
+         __Test.NumbersArray != null && __Test.NumbersArray.Contains(2) || __Test.NumbersArray != null && __Test.NumbersArray.Contains(5));
+
+      // act
+      var actual = dataSource.ApplyFiltering("NumbersArray=2|NumbersArray=5");
+
+      // assert
+      Assert.Equal(expected.ToString(), actual.ToString());
+      var actualList = actual.ToList();
+      Assert.Equal(expected.ToList(), actualList);
+      Assert.Single(actualList);
+      GridifyGlobalConfiguration.DisableNullChecks = false;
+   }
+
+   [Fact]
+   public void ApplyFiltering_WithoutMapper_ShouldGenerateMappingsForEnumArray()
+   {
+      // arrange
+      var dataSource = new List<Test>()
+      {
+         new() {EnumsArray = [Test.MyEnum.Item1, Test.MyEnum.Item2]},
+         new() {EnumsArray = [Test.MyEnum.Item1]},
+      }.AsQueryable();
+
+      var expected = dataSource.Where(__Test =>
+         __Test.EnumsArray != null && __Test.EnumsArray.Contains(Test.MyEnum.Item1) ||
+         __Test.EnumsArray != null && __Test.EnumsArray.Contains(Test.MyEnum.Item2));
+
+      // act
+      var actual = dataSource.ApplyFiltering("EnumsArray=Item1|EnumsArray=Item2");
+
+      // assert
+      Assert.Equal(expected.ToString(), actual.ToString());
+      var actualList = actual.ToList();
+      Assert.Equal(expected.ToList(), actualList);
+      Assert.Equal(2, actualList.Count);
+   }
+
+
+   private class Test
+   {
+      public List<string> FavouriteColorList { get; set; } = [];
+      public string[] FavouriteColorsArray { get; set; } = [];
+
+      public int[] NumbersArray { get; set; } = [];
+      public IEnumerable<long> NumbersEnumerable { get; set; } = [];
+      public MyEnum[] EnumsArray { get; set; } = [];
+
+      public enum MyEnum
+      {
+         Item1,
+         Item2
+      }
+
    }
 }


### PR DESCRIPTION
BenchmarkDotNet v0.13.10, Windows 11 (10.0.22631.3737/23H2/2023Update/SunValley3)
AMD Ryzen 7 7800X3D, 1 CPU, 16 logical and 8 physical cores
.NET SDK 8.0.206
  [Host]     : .NET 8.0.6 (8.0.624.26715), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.6 (8.0.624.26715), X64 RyuJIT AVX2


| Method                | Mean     | Error    | StdDev   | Ratio | RatioSD | Allocated | Alloc Ratio |
|---------------------- |---------:|---------:|---------:|------:|--------:|----------:|------------:|
| Gridify               | 591.8 us |  5.41 us |  5.07 us |  0.92 |    0.04 |  35.65 KB |        1.09 |
| Gridify_WithoutMapper | 603.4 us |  4.39 us |  4.10 us |  0.94 |    0.04 |  40.81 KB |        1.25 |
| Native_LINQ           | 636.1 us | 11.31 us | 18.90 us |  1.00 |    0.00 |  32.63 KB |        1.00 |