### PR TITLE
fix: pass on maxNestingDepth to GenerateMappings

### DIFF
--- a/src/Gridify/GridifyMapper.cs
+++ b/src/Gridify/GridifyMapper.cs
@@ -18,7 +18,7 @@ public class GridifyMapper<T> : IGridifyMapper<T>
       _mappings = new List<IGMap<T>>();
 
       if (autoGenerateMappings)
-         GenerateMappings();
+         GenerateMappings(maxNestingDepth);
    }
 
    public GridifyMapper(GridifyMapperConfiguration configuration, bool autoGenerateMappings = false)


### PR DESCRIPTION
# Description

This PR fixes an issue where the maxNestingDepth constructor param of GridifyMapper is not being passed on to the GenerateMappings function

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
