### PR TITLE
Default DateTimeKind configuration

### DIFF
--- a/docs/pages/guide/gridifyGlobalConfiguration.md
+++ b/docs/pages/guide/gridifyGlobalConfiguration.md
@@ -47,6 +47,13 @@ some ORMs like NHibernate don't support this. You can disable this behavior by s
 - type: `bool`
 - default: `false`
 
+### DefaultDateTimeKind
+
+By default, Gridify uses the `DateTimeKind.Unspecified` when parsing dates. You can change this behavior by setting this property to `DateTimeKind.Utc` or `DateTimeKind.Local`. This option is useful when you want to use Gridify with a database that requires a specific `DateTimeKind`, for example when using npgsql and postgresql. 
+
+- type: `DateTimeKind`
+- default: `null`
+
 ## CustomOperators
 
 Using the `Register` method of this property you can add your own custom operators.

--- a/docs/pages/guide/gridifyMapper.md
+++ b/docs/pages/guide/gridifyMapper.md
@@ -144,7 +144,6 @@ By setting this to `false`, Gridify don't allow searching on null values using t
 var mapper = new GridifyMapper<Person>(q => q.AllowNullSearch = false);
 ```
 
-
 ### DefaultDateTimeKind
 
 By setting this property to a `DateTimeKind` value, you can change the default `DateTimeKind` used when parsing dates.
@@ -152,6 +151,9 @@ By setting this property to a `DateTimeKind` value, you can change the default `
 - type: `DateTimeKind`
 - default: `null`
 
+``` csharp
+var mapper = new GridifyMapper<Person>(q => q.DefaultDateTimeKind = DateTimeKind.Utc);
+```
 
 ## Filtering on Nested Collections
 

--- a/docs/pages/guide/gridifyMapper.md
+++ b/docs/pages/guide/gridifyMapper.md
@@ -144,6 +144,15 @@ By setting this to `false`, Gridify don't allow searching on null values using t
 var mapper = new GridifyMapper<Person>(q => q.AllowNullSearch = false);
 ```
 
+
+### DefaultDateTimeKind
+
+By setting this property to a `DateTimeKind` value, you can change the default `DateTimeKind` used when parsing dates.
+
+- type: `DateTimeKind`
+- default: `null`
+
+
 ## Filtering on Nested Collections
 
 You can use LINQ `Select` and `SelectMany` methods to filter your data using its nested collections.

--- a/src/Gridify/Builder/BaseQueryBuilder.cs
+++ b/src/Gridify/Builder/BaseQueryBuilder.cs
@@ -198,6 +198,14 @@ public abstract class BaseQueryBuilder<TQuery, T>(IGridifyMapper<T> mapper)
             {
                return BuildAlwaysFalseQuery(parameter);
             }
+         
+         if (value is DateTime dateTime)
+         {
+            if (GridifyGlobalConfiguration.DefaultDateTimeKind.HasValue)
+            {
+               value = DateTime.SpecifyKind(dateTime, GridifyGlobalConfiguration.DefaultDateTimeKind.Value);
+            }
+         }
       }
 
       // handle case-Insensitive search

--- a/src/Gridify/Builder/BaseQueryBuilder.cs
+++ b/src/Gridify/Builder/BaseQueryBuilder.cs
@@ -201,9 +201,9 @@ public abstract class BaseQueryBuilder<TQuery, T>(IGridifyMapper<T> mapper)
          
          if (value is DateTime dateTime)
          {
-            if (GridifyGlobalConfiguration.DefaultDateTimeKind.HasValue)
+            if (mapper.Configuration.DefaultDateTimeKind.HasValue)
             {
-               value = DateTime.SpecifyKind(dateTime, GridifyGlobalConfiguration.DefaultDateTimeKind.Value);
+               value = DateTime.SpecifyKind(dateTime, mapper.Configuration.DefaultDateTimeKind.Value);
             }
          }
       }

--- a/src/Gridify/GridifyGlobalConfiguration.cs
+++ b/src/Gridify/GridifyGlobalConfiguration.cs
@@ -46,6 +46,13 @@ namespace Gridify
       /// Default is false
       /// </summary>
       public static bool DisableNullChecks { get; set; } = false;
+      
+      /// <summary>
+      /// By default, DateTimeKind.Unspecified is used.
+      /// You can change this behavior by setting this property to a DateTimeKind value.
+      /// Default is null
+      /// </summary>
+      public static DateTimeKind? DefaultDateTimeKind { get; set; } = null;
 
       /// <summary>
       /// Specifies how field names are inferred from CLR property names.

--- a/src/Gridify/GridifyMapperConfiguration.cs
+++ b/src/Gridify/GridifyMapperConfiguration.cs
@@ -23,6 +23,13 @@ public record GridifyMapperConfiguration
    /// Default is false
    /// </summary>
    public bool IgnoreNotMappedFields { get; set; } = GridifyGlobalConfiguration.IgnoreNotMappedFields;
+   
+   /// <summary>
+   /// By default, DateTimeKind.Unspecified is used.
+   /// You can change this behavior by setting this property to a DateTimeKind value.
+   /// Default is null
+   /// </summary>
+   public DateTimeKind? DefaultDateTimeKind { get; set; } = GridifyGlobalConfiguration.DefaultDateTimeKind;
 
    /// <summary>
    /// Specifies how field names are inferred from CLR property names.

--- a/test/EntityFrameworkPostgreSqlIntegrationTests/Issue188Tests.cs
+++ b/test/EntityFrameworkPostgreSqlIntegrationTests/Issue188Tests.cs
@@ -1,0 +1,30 @@
+using EntityFrameworkIntegrationTests.cs;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Gridify.Tests;
+
+public class Issue188Tests
+{
+
+   private readonly MyDbContext _dbContext = new();
+
+   [Fact]
+   public void DateTimeFilteringWithUTCKind_UsingGridifyMapper_ShouldNotThrowException()
+   {
+      var mapper = new GridifyMapper<User>(q => q.DefaultDateTimeKind = DateTimeKind.Utc)
+         .GenerateMappings();
+      _dbContext.Users.ApplyFiltering("CreateDate>2023-11-14", mapper).ToQueryString();
+   }
+
+   [Fact]
+   public void DateTimeFilteringWithUTCKind_UsingGlobalConfiguration_ShouldNotThrowException()
+   {
+      GridifyGlobalConfiguration.DefaultDateTimeKind = DateTimeKind.Utc;
+      _dbContext.Users.ApplyFiltering("CreateDate>2023-11-14").ToQueryString();
+      GridifyGlobalConfiguration.DefaultDateTimeKind = null;
+   }
+
+}
+
+


### PR DESCRIPTION
# Description

This is so we can specify a DateTimeKind to the dates that are parsed. More details in the issue. 

Fixes # [(issue)](https://github.com/alirezanet/Gridify/issues/188)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
