### PR TITLE
Get Maps by Type

### DIFF
--- a/docs/pages/guide/gridifyMapper.md
+++ b/docs/pages/guide/gridifyMapper.md
@@ -103,6 +103,10 @@ This method clears the list of mappings
 
 This method returns list of current mappings.
 
+## GetCurrentMapsByType
+
+This method returns list of current mappings for the given type.
+
 ## GridifyMapperConfiguration
 
 ``` csharp

--- a/src/Gridify/GridifyMapper.cs
+++ b/src/Gridify/GridifyMapper.cs
@@ -220,6 +220,26 @@ public class GridifyMapper<T> : IGridifyMapper<T>
    {
       return _mappings;
    }
+   
+   public IEnumerable<IGMap<T>> GetCurrentMapsByType(HashSet<Type> targetTypes)
+   {
+      foreach (var map in _mappings)
+      {
+         if (map.To.Body is UnaryExpression unaryExpression)
+         {
+            if (targetTypes.Contains(unaryExpression.Operand.Type))
+            {
+               yield return map;
+            }
+         }
+         // TODO: need to implement other types that aren't unary expression
+      }
+   }
+
+   public IEnumerable<IGMap<T>> GetCurrentMapsByType<TTarget>()
+   {
+      return GetCurrentMapsByType([typeof(TTarget)]);
+   }
 
    /// <summary>
    /// Converts current mappings to a comma seperated list of map names.

--- a/src/Gridify/GridifyMapper.cs
+++ b/src/Gridify/GridifyMapper.cs
@@ -232,7 +232,20 @@ public class GridifyMapper<T> : IGridifyMapper<T>
                yield return map;
             }
          }
-         // TODO: need to implement other types that aren't unary expression
+         else if (map.To.Body is MethodCallExpression methodCallExpression)
+         {
+            if (targetTypes.Contains(methodCallExpression.Type))
+            {
+               yield return map;
+            }
+         }
+         else if (map.To.Body is MemberExpression memberExpression)
+         {
+            if (targetTypes.Contains(memberExpression.Type))
+            {
+               yield return map;
+            }
+         }
       }
    }
 

--- a/src/Gridify/GridifyMapper.cs
+++ b/src/Gridify/GridifyMapper.cs
@@ -225,25 +225,34 @@ public class GridifyMapper<T> : IGridifyMapper<T>
    {
       foreach (var map in _mappings)
       {
-         if (map.To.Body is UnaryExpression unaryExpression)
+         switch (map.To.Body)
          {
-            if (targetTypes.Contains(unaryExpression.Operand.Type))
+            case UnaryExpression unaryExpression:
             {
-               yield return map;
+               if (targetTypes.Contains(unaryExpression.Operand.Type))
+               {
+                  yield return map;
+               }
+
+               break;
             }
-         }
-         else if (map.To.Body is MethodCallExpression methodCallExpression)
-         {
-            if (targetTypes.Contains(methodCallExpression.Type))
+            case MethodCallExpression methodCallExpression:
             {
-               yield return map;
+               if (targetTypes.Contains(methodCallExpression.Type))
+               {
+                  yield return map;
+               }
+
+               break;
             }
-         }
-         else if (map.To.Body is MemberExpression memberExpression)
-         {
-            if (targetTypes.Contains(memberExpression.Type))
+            case MemberExpression memberExpression:
             {
-               yield return map;
+               if (targetTypes.Contains(memberExpression.Type))
+               {
+                  yield return map;
+               }
+
+               break;
             }
          }
       }

--- a/src/Gridify/IGridifyMapper.cs
+++ b/src/Gridify/IGridifyMapper.cs
@@ -47,5 +47,7 @@ public interface IGridifyMapper<T>
    bool HasMap(string key);
    public GridifyMapperConfiguration Configuration { get; }
    IEnumerable<IGMap<T>> GetCurrentMaps();
+   IEnumerable<IGMap<T>> GetCurrentMapsByType<TTarget>();
+   IEnumerable<IGMap<T>> GetCurrentMapsByType(HashSet<Type> targetTypes);
    void ClearMappings();
 }

--- a/test/Gridify.Tests/GridifyMapperShould.cs
+++ b/test/Gridify.Tests/GridifyMapperShould.cs
@@ -149,15 +149,31 @@ public class GridifyMapperShould
       //The thrown exception can be used for even more detailed assertions.
       Assert.Equal("Duplicate Key. the 'test' key already exists", exception.Message);
    }
-
-
-   [Fact]
-   public void GetMappingByType()
+   
+   [Theory]
+   [InlineData(typeof(DateTime), 0)]
+   [InlineData(typeof(DateTime?), 1)]
+   [InlineData(typeof(Guid), 1)]
+   [InlineData(typeof(string), 2)]
+   [InlineData(typeof(bool), 1)]
+   [InlineData(typeof(int), 1)]
+   public void GetMappingByType(Type filterType, int count)
    {
       var gm = new GridifyMapper<TestClass>(true);
-
-      var dates = gm.GetCurrentMapsByType([typeof(DateTime), typeof(DateTime?)]);
-
-      Assert.Single(dates);
+      var maps = gm.GetCurrentMapsByType([filterType]);
+      Assert.Equal(count, maps.Count());
    }
+
+   [Fact]
+   public void GetMappingsByCustomType()
+   {
+      var gm = new GridifyMapper<TypeMappingTest>().GenerateMappings();
+      var maps = gm.GetCurrentMapsByType([typeof(IEnumerable<string>)]);
+      Assert.Single(maps);
+   }
+}
+
+public class TypeMappingTest
+{
+   public List<string> MyListString { get; set; } = [];
 }

--- a/test/Gridify.Tests/GridifyMapperShould.cs
+++ b/test/Gridify.Tests/GridifyMapperShould.cs
@@ -151,6 +151,13 @@ public class GridifyMapperShould
    }
 
 
+   [Fact]
+   public void GetMappingByType()
+   {
+      var gm = new GridifyMapper<TestClass>(true);
 
+      var dates = gm.GetCurrentMapsByType([typeof(DateTime), typeof(DateTime?)]);
 
+      Assert.Single(dates);
+   }
 }

--- a/test/Gridify.Tests/GridifyMapperShould.cs
+++ b/test/Gridify.Tests/GridifyMapperShould.cs
@@ -151,7 +151,7 @@ public class GridifyMapperShould
    }
    
    [Theory]
-   [InlineData(typeof(DateTime), 0)]
+   [InlineData(typeof(DateTime), 1)]
    [InlineData(typeof(DateTime?), 1)]
    [InlineData(typeof(Guid), 1)]
    [InlineData(typeof(string), 2)]

--- a/test/Gridify.Tests/TestClass.cs
+++ b/test/Gridify.Tests/TestClass.cs
@@ -25,6 +25,7 @@ public class TestClass : ICloneable
    public string? Name { get; set; } = string.Empty;
    public TestClass? ChildClass { get; set; }
    public DateTime? MyDateTime { get; set; }
+   public DateTime AnotherDateTime { get; set; }
    public Guid MyGuid { get; set; }
    public string? Tag { get; set; }
 


### PR DESCRIPTION
# Description

Added a method in mapper to return the maps by type. This can be used to define custom value convertors by the caller. 

Discussion - https://github.com/alirezanet/Gridify/discussions/213
Related issue - #211 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
