### PR TITLE
Changing package versions for net8.0

### DIFF
--- a/src/Gridify.EntityFramework/Gridify.EntityFramework.csproj
+++ b/src/Gridify.EntityFramework/Gridify.EntityFramework.csproj
@@ -41,7 +41,7 @@
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[7.0.0,8.0.0)" />
    </ItemGroup>
    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[8.0.0,9.0.0)" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[8.0.0,10.0.0)" />
    </ItemGroup>
    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[9.0.0,10.0.0)" />

--- a/src/Gridify/Gridify.csproj
+++ b/src/Gridify/Gridify.csproj
@@ -31,7 +31,7 @@
    </ItemGroup>
 
    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[8.0.0,9.0.0)" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[8.0.0,10.0.0)" />
    </ItemGroup>
 
    <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">


### PR DESCRIPTION
# Changing package versions for net8.0

The `Gridify.EntityFramework.csproj` file has changed the version of the `Microsoft.EntityFrameworkCore` package for the `net8.0` target platform. Previously the version was specified as `[8.0.0,9.0.0)`, now it has been changed to `[8.0.0,10.0.0)`.

In the `Gridify.csproj` file, the version of the `Microsoft.Extensions.DependencyInjection.Abstractions` package for the `net8.0` target platform has been changed. Previously the version was specified as `[8.0.0,9.0.0)`, now it has been changed to `[8.0.0,10.0.0)`.

Fixes [# 240](https://github.com/alirezanet/Gridify/issues/240)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
