### PR TITLE
xml docs and input parameter's nullability fix

### DIFF
--- a/src/Gridify/GridifyExtensions.cs
+++ b/src/Gridify/GridifyExtensions.cs
@@ -492,7 +492,7 @@ public static partial class GridifyExtensions
    /// <param name="gridifyQuery">the configuration to apply paging, filtering and ordering</param>
    /// <param name="mapper">this is an optional parameter to apply filtering and ordering using a custom mapping configuration</param>
    /// <typeparam name="T">type of target entity</typeparam>
-   /// <returns>returns a <c>QueryablePaging<T><c/> after applying filtering, ordering and paging</returns>
+   /// <returns>returns a <c>QueryablePaging{T}</c> after applying filtering, ordering and paging</returns>
    public static QueryablePaging<T> GridifyQueryable<T>(this IQueryable<T> query, IGridifyQuery? gridifyQuery, IGridifyMapper<T>? mapper = null)
    {
       query = query.ApplyFiltering(gridifyQuery, mapper);
@@ -512,7 +512,7 @@ public static partial class GridifyExtensions
    /// <param name="gridifyQuery">the configuration to apply paging, filtering and ordering</param>
    /// <param name="mapper">this is an optional parameter to apply filtering and ordering using a custom mapping configuration</param>
    /// <typeparam name="T">type of target entity</typeparam>
-   /// <returns>returns a loaded <c>Paging<T><c /> after applying filtering, ordering and paging </returns>
+   /// <returns>returns a loaded <c>Paging{T}</c> after applying filtering, ordering and paging </returns>
    /// <returns></returns>
    public static Paging<T> Gridify<T>(this IQueryable<T> query, IGridifyQuery? gridifyQuery, IGridifyMapper<T>? mapper = null)
    {
@@ -530,7 +530,7 @@ public static partial class GridifyExtensions
    /// <param name="queryOption">the configuration to apply paging, filtering and ordering</param>
    /// <param name="mapper">this is an optional parameter to apply filtering and ordering using a custom mapping configuration</param>
    /// <typeparam name="T">type of target entity</typeparam>
-   /// <returns>returns a loaded <c>Paging<T><c /> after applying filtering, ordering and paging </returns>
+   /// <returns>returns a loaded <c>Paging{T}</c> after applying filtering, ordering and paging </returns>
    /// <returns></returns>
    public static Paging<T> Gridify<T>(this IQueryable<T> query, Action<IGridifyQuery> queryOption, IGridifyMapper<T>? mapper = null)
    {

--- a/src/Gridify/GridifyQuery.cs
+++ b/src/Gridify/GridifyQuery.cs
@@ -5,7 +5,7 @@ public class GridifyQuery : IGridifyQuery
    public GridifyQuery()
    {
    }
-   public GridifyQuery(int page, int pageSize, string filter, string? orderBy = null)
+   public GridifyQuery(int page, int pageSize, string? filter, string? orderBy = null)
    {
       Page = page;
       PageSize = pageSize;


### PR DESCRIPTION
# Description
This pr fixes a constructor parameter "filter" of GridifyQuery. It is 'string' even though property is 'string?' in nullable context passing null creates a warning (and is in general confusing), but passing empty string will fail QueryBuilder<T>.BuildEvaluator().

Also some XML documentation had issues which in term broke documentation in rider, also fixed that.

I haven't created an issue for that

## Type of change

- xml documentation and parameter nullability
