### PR TITLE
Bug fix: Convert dateTimes

### DIFF
--- a/src/Gridify/Builder/BaseQueryBuilder.cs
+++ b/src/Gridify/Builder/BaseQueryBuilder.cs
@@ -204,7 +204,7 @@ public abstract class BaseQueryBuilder<TQuery, T>(IGridifyMapper<T> mapper)
          {
             if (mapper.Configuration.DefaultDateTimeKind.HasValue)
             {
-               value = DateTime.SpecifyKind(dateTime, mapper.Configuration.DefaultDateTimeKind.Value);
+               value = dateTime.ToUniversalTime();
             }
          }
       }

--- a/src/Gridify/Builder/BaseQueryBuilder.cs
+++ b/src/Gridify/Builder/BaseQueryBuilder.cs
@@ -204,7 +204,12 @@ public abstract class BaseQueryBuilder<TQuery, T>(IGridifyMapper<T> mapper)
          {
             if (mapper.Configuration.DefaultDateTimeKind.HasValue)
             {
-               value = dateTime.ToUniversalTime();
+               value = mapper.Configuration.DefaultDateTimeKind.Value switch
+               {
+                  DateTimeKind.Local => dateTime.ToLocalTime(),
+                  DateTimeKind.Utc => dateTime.ToUniversalTime(),
+                  _ => dateTime
+               };
             }
          }
       }

--- a/test/EntityFrameworkPostgreSqlIntegrationTests/PR266Tests.cs
+++ b/test/EntityFrameworkPostgreSqlIntegrationTests/PR266Tests.cs
@@ -1,0 +1,60 @@
+using EntityFrameworkIntegrationTests.cs;
+using Gridify;
+using Microsoft.EntityFrameworkCore;
+using System.Globalization;
+using Xunit;
+
+namespace EntityFrameworkPostgreSqlIntegrationTests;
+
+public class PR266Tests
+{
+   private readonly MyDbContext _dbContext = new();
+
+   [Fact]
+   public void ISO_Should_Convert_ToUTC()
+   {
+      var isoTimestamp = "2025-03-31T02:54:09Z";
+
+      var mapper = new GridifyMapper<User>(q => q.DefaultDateTimeKind = DateTimeKind.Utc).GenerateMappings();
+      var queryString = _dbContext.Users.ApplyFiltering($"CreateDate={isoTimestamp}", mapper).ToQueryString();
+
+      var whereClause = queryString.Split("WHERE")[1].Trim();
+      Assert.Equal($"u.\"CreateDate\" = TIMESTAMPTZ '{isoTimestamp}'", whereClause);
+   }
+
+   [Fact]
+   public void ISO_Should_ShowcaseDifferentConversions_LocalToUtc()
+   {
+      var localDt = DateTime.Parse("2025-03-31T02:54:09Z", new CultureInfo("lt-LT"));
+      Assert.Equal(DateTimeKind.Local, localDt.Kind);
+      Assert.Equal("2025-03-31T05:54:09", localDt.ToString("s"));
+
+      // Past behavior. Kind becomes Utc, but time is not converted.
+      var utcDtWrong = DateTime.SpecifyKind(localDt, DateTimeKind.Utc);
+      Assert.Equal(DateTimeKind.Utc, utcDtWrong.Kind);
+      Assert.Equal("2025-03-31T05:54:09", utcDtWrong.ToString("s"));
+
+      // Current behavior. Kind becomes Utc, and time is converted.
+      var utcDtCorrect = localDt.ToUniversalTime();
+      Assert.Equal(DateTimeKind.Utc, utcDtCorrect.Kind);
+      Assert.Equal("2025-03-31T02:54:09", utcDtCorrect.ToString("s"));
+   }
+
+   [Fact]
+   public void ISO_Should_ShowcaseDifferentConversions_UtcToLocal()
+   {
+      var utcDt = DateTime.Parse("2025-03-31T02:54:09Z", new CultureInfo("lt-LT")).ToUniversalTime();
+      Assert.Equal(DateTimeKind.Utc, utcDt.Kind);
+      Assert.Equal("2025-03-31T02:54:09", utcDt.ToString("s"));
+
+      // Past behavior. Kind becomes Local, but time is not converted.
+      var localDtWrong = DateTime.SpecifyKind(utcDt, DateTimeKind.Local);
+      Assert.Equal(DateTimeKind.Local, localDtWrong.Kind);
+      Assert.Equal("2025-03-31T02:54:09", localDtWrong.ToString("s"));
+
+      // Current behavior. Kind becomes Local, and time is converted.
+      var localDtCorrect = utcDt.ToLocalTime();
+      Assert.Equal(DateTimeKind.Local, localDtCorrect.Kind);
+      Assert.Equal("2025-03-31T05:54:09", localDtCorrect.ToString("s"));
+   }
+}

--- a/test/EntityFrameworkPostgreSqlIntegrationTests/PR266Tests.cs
+++ b/test/EntityFrameworkPostgreSqlIntegrationTests/PR266Tests.cs
@@ -1,7 +1,6 @@
 using EntityFrameworkIntegrationTests.cs;
 using Gridify;
 using Microsoft.EntityFrameworkCore;
-using System.Globalization;
 using Xunit;
 
 namespace EntityFrameworkPostgreSqlIntegrationTests;
@@ -25,36 +24,38 @@ public class PR266Tests
    [Fact]
    public void ISO_Should_ShowcaseDifferentConversions_LocalToUtc()
    {
-      var localDt = DateTime.Parse("2025-03-31T02:54:09Z", new CultureInfo("lt-LT"));
+      var localOffset = TimeZoneInfo.Local.GetUtcOffset(DateTime.Now);
+
+      var localDt = DateTime.Parse("2025-03-31T02:54:09Z");
       Assert.Equal(DateTimeKind.Local, localDt.Kind);
-      Assert.Equal("2025-03-31T05:54:09", localDt.ToString("s"));
 
       // Past behavior. Kind becomes Utc, but time is not converted.
       var utcDtWrong = DateTime.SpecifyKind(localDt, DateTimeKind.Utc);
       Assert.Equal(DateTimeKind.Utc, utcDtWrong.Kind);
-      Assert.Equal("2025-03-31T05:54:09", utcDtWrong.ToString("s"));
+      Assert.Equal(localDt, utcDtWrong);
 
       // Current behavior. Kind becomes Utc, and time is converted.
       var utcDtCorrect = localDt.ToUniversalTime();
       Assert.Equal(DateTimeKind.Utc, utcDtCorrect.Kind);
-      Assert.Equal("2025-03-31T02:54:09", utcDtCorrect.ToString("s"));
+      Assert.Equal(localDt.Subtract(localOffset), utcDtCorrect);
    }
 
    [Fact]
    public void ISO_Should_ShowcaseDifferentConversions_UtcToLocal()
    {
-      var utcDt = DateTime.Parse("2025-03-31T02:54:09Z", new CultureInfo("lt-LT")).ToUniversalTime();
+      var localOffset = TimeZoneInfo.Local.GetUtcOffset(DateTime.Now);
+
+      var utcDt = DateTime.Parse("2025-03-31T02:54:09Z").ToUniversalTime();
       Assert.Equal(DateTimeKind.Utc, utcDt.Kind);
-      Assert.Equal("2025-03-31T02:54:09", utcDt.ToString("s"));
 
       // Past behavior. Kind becomes Local, but time is not converted.
       var localDtWrong = DateTime.SpecifyKind(utcDt, DateTimeKind.Local);
       Assert.Equal(DateTimeKind.Local, localDtWrong.Kind);
-      Assert.Equal("2025-03-31T02:54:09", localDtWrong.ToString("s"));
+      Assert.Equal(utcDt, localDtWrong);
 
       // Current behavior. Kind becomes Local, and time is converted.
       var localDtCorrect = utcDt.ToLocalTime();
       Assert.Equal(DateTimeKind.Local, localDtCorrect.Kind);
-      Assert.Equal("2025-03-31T05:54:09", localDtCorrect.ToString("s"));
+      Assert.Equal(utcDt.Add(localOffset), localDtCorrect);
    }
 }


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

I store UTC timestamps in DB, and pass ISO timestamps for filtering operations.
When ISO timestamp is passed, it's first converted to `DateTime` with additional local timezone offset. Later, it's `Kind` is set to UTC. This only changes the `Kind` property, retaining the previously added timezone ticks.
![image](https://github.com/user-attachments/assets/7c8673b4-3dca-475e-b358-a524d80385fe)
![image](https://github.com/user-attachments/assets/e393bf69-81ef-4c36-98d9-b15e12e76c71)
![image](https://github.com/user-attachments/assets/2634868d-a22a-48de-87f5-18a3b680ac8c)

For this reason, the following request:
![image](https://github.com/user-attachments/assets/9bf448da-7732-4577-a4fb-d4962a3f94a8)
Turns into this query:
![image](https://github.com/user-attachments/assets/ae64a41d-292a-4e6c-8d5f-32d846f9a5ca)


This behavior can be easily reproduced with the following sample, when environment has a timezone:
```csharp
var dateTime = DateTime.Now;
Console.WriteLine(dateTime);

var utcDateTime = DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
Console.WriteLine(utcDateTime);

var utcDateTime2 = dateTime.ToUniversalTime();
Console.WriteLine(utcDateTime2);
```

![image](https://github.com/user-attachments/assets/12442fcc-e451-4e4f-be7d-89aed387a19c)


Fixes # (issue)
-

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
