### PR TITLE
feat(client): Allow the client to be used more flexibly

### DIFF
--- a/client/src/GridifyQueryBuilder.ts
+++ b/client/src/GridifyQueryBuilder.ts
@@ -82,13 +82,18 @@ export class GridifyQueryBuilder {
    and(optional?: boolean): GridifyQueryBuilder {
       this.filteringExpressions.push({
          value: LogicalOperator.And,
-         type: "op", optional
+         type: "op",
+         optional
       });
       return this;
    }
 
    or(optional?: boolean): GridifyQueryBuilder {
-      this.filteringExpressions.push({ value: LogicalOperator.Or, type: "op", optional });
+      this.filteringExpressions.push({
+         value: LogicalOperator.Or,
+         type: "op",
+         optional
+      });
       return this;
    }
 
@@ -163,6 +168,9 @@ export class GridifyQueryBuilder {
       if (groupCounter != 0) {
          throw new Error("Group not properly closed");
       }
+
+      // postprocess
+      this.query.filter = this.query.filter?.replace(/[,|]?\(\)/gi, "");
 
       return this.query;
    }

--- a/client/src/GridifyQueryBuilderOptions.ts
+++ b/client/src/GridifyQueryBuilderOptions.ts
@@ -1,0 +1,6 @@
+import { GridifyQueryBuilder } from "./GridifyQueryBuilder";
+
+export interface GridifyQueryBuilderOptions {
+    from?: GridifyQueryBuilder;
+    allowEmptyGroups?: boolean;
+}

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,13 +1,14 @@
 {
    "compilerOptions": {
-     "target": "es5",
-     "module": "ES2015",
-     "declaration": true,
-     "outDir": "./dist",
-     "esModuleInterop": true,
-     "strict": true,
-     "sourceMap": true
+      "target": "ES5",
+      "lib": ["ES2017"],
+      "module": "ES2015",
+      "declaration": true,
+      "outDir": "./dist",
+      "esModuleInterop": true,
+      "strict": true,
+      "sourceMap": true
    },
    "include": ["src/**/*"],
    "exclude": ["node_modules", "test", "**/*.test.ts"]
- }
+}

--- a/docs/pages/guide/extensions/gridify-client.md
+++ b/docs/pages/guide/extensions/gridify-client.md
@@ -17,6 +17,21 @@ npm i gridify-client
 The `GridifyQueryBuilder` interface represents the methods available for constructing dynamic queries using the Gridify
 Client library.
 
+When creating a new instance of `GridifyQueryBuilder`, you can pass an optional `GridifyQueryBuilderOptions` object to the constructor. This allows you to configure advanced behaviors:
+
+- `from`: Clone an existing builder's state.
+- `allowEmptyGroups`: Allow empty logical groups in the filter expression (default is `false`).
+
+**Example:**
+
+```ts
+import { GridifyQueryBuilder } from "gridify-client";
+
+const builder = new GridifyQueryBuilder({
+  allowEmptyGroups: true
+});
+```
+
 The following table describes the methods available in the GridifyQueryBuilder interface for constructing dynamic queries.
 
 | Method       | Parameter                                          | Description                                                                                                           |
@@ -27,10 +42,12 @@ The following table describes the methods available in the GridifyQueryBuilder i
 | addCondition | field, operator, value, caseSensitive, escapeValue | Add filtering conditions. `caseSensitive` and `escapeValue` are optional parameters.                                  |
 | startGroup   | -                                                  | Start a logical grouping of conditions.                                                                               |
 | endGroup     | -                                                  | End the current logical group.                                                                                        |
-| and          | -                                                  | Add the logical AND operator.                                                                                         |
-| or           | -                                                  | Add the logical OR operator.                                                                                          |
+| and          | optional?: boolean                                 | Add the logical AND operator. If `optional` is `true`, the operator will be ignored if it would be invalid in the current context. |
+| or           | optional?: boolean                                 | Add the logical OR operator. If `optional` is `true`, the operator will be ignored if it would be invalid in the current context.  |
 | build        | -                                                  | Build and retrieve the constructed query.                                                                             |
 
+> **Note:**  
+> The `and` and `or` methods accepts an optional boolean parameter. If set to `true`, the logical operator will be treated as optional and ignored if it would result in an invalid expression (such as being the first operator or consecutive with another operator).
 
 ## Conditional Operators
 
@@ -86,3 +103,4 @@ Output:
   "filter": "(age<50|name^A),isActive=true"
 }
 ```
+


### PR DESCRIPTION
# Description

We use Gridify in a base table component, which adds it's own current state (such as pageSize, page, filter, sorting) within a group.
The query builder instance is not automatically built, so parent component users can add more filters.

Because of this, there may be situations - such as the grid having no specific filtering state that empty groups can occour. In that case, we would want to simply "skip" this group.

Another case would be, the base table adds its filters and we want to concatinate it with an `and()` or `or()`, but if the table did not create a filter group, both operations are only informational _if_ it would have other conditions.

This PR addresses both problems as well as a bit of housekeeping in the tsconfig.
This PR also changes the query and filterExpressions to be protected, making it easier to extend the class and manage edge cases whose may not belong to the core library itself manually.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
