### PR TITLE
fix: skip case-insensitive ToLower for non-string types in BaseQueryBuilder

### DIFF
--- a/src/Gridify/Builder/BaseQueryBuilder.cs
+++ b/src/Gridify/Builder/BaseQueryBuilder.cs
@@ -320,8 +320,8 @@ public abstract class BaseQueryBuilder<TQuery, T>(IGridifyMapper<T> mapper)
       }
 
       // handle case-Insensitive search
-      if (value is not null && (valueExpression.IsCaseInsensitive
-                            || (mapper.Configuration.CaseInsensitiveFiltering && body.Type == typeof(string)))
+      if (value is not null && body.Type == typeof(string) && (valueExpression.IsCaseInsensitive
+                            || mapper.Configuration.CaseInsensitiveFiltering)
                             && op.Kind is not SyntaxKind.GreaterThan
                             && op.Kind is not SyntaxKind.LessThan
                             && op.Kind is not SyntaxKind.GreaterOrEqualThan

--- a/test/Gridify.Tests/IssueTests/CaseInsensitiveNonStringFilterTest.cs
+++ b/test/Gridify.Tests/IssueTests/CaseInsensitiveNonStringFilterTest.cs
@@ -52,10 +52,8 @@ public class CaseInsensitiveNonStringFilterTest
       var mapper = new GridifyMapper<TestClass>(q => q.CaseInsensitiveFiltering = true)
           .GenerateMappings();
 
-      var actual = DataSource.AsQueryable()
-          .ApplyFiltering($"MyGuid={TestGuid}", mapper)
-          .ToList();
-
-      Assert.Single(actual);
+      Assert.Single(DataSource.AsQueryable().ApplyFiltering($"MyGuid={TestGuid}", mapper).ToList());
+      Assert.Single(DataSource.AsQueryable().ApplyFiltering("Id=1", mapper).ToList());
+      Assert.Single(DataSource.AsQueryable().ApplyFiltering("IsActive=true", mapper).ToList());
    }
 }

--- a/test/Gridify.Tests/IssueTests/CaseInsensitiveNonStringFilterTest.cs
+++ b/test/Gridify.Tests/IssueTests/CaseInsensitiveNonStringFilterTest.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Gridify.Tests.IssueTests;
+
+public class CaseInsensitiveNonStringFilterTest
+{
+   private static readonly Guid TestGuid = Guid.Parse("12345678-1234-1234-1234-123456789abc");
+
+   private List<TestClass> DataSource => new()
+    {
+        new TestClass { Id = 1, MyGuid = TestGuid, IsActive = true },
+        new TestClass { Id = 2, MyGuid = Guid.NewGuid(), IsActive = false },
+        new TestClass { Id = 3, MyGuid = Guid.NewGuid(), IsActive = false },
+    };
+
+   [Fact]
+   public void ApplyFiltering_WithCaseInsensitiveOperator_OnGuidProperty_ShouldNotThrow()
+   {
+      var actual = DataSource.AsQueryable()
+          .ApplyFiltering($"MyGuid={TestGuid}/i")
+          .ToList();
+
+      Assert.Single(actual);
+   }
+
+   [Fact]
+   public void ApplyFiltering_WithCaseInsensitiveOperator_OnIntProperty_ShouldNotThrow()
+   {
+      var actual = DataSource.AsQueryable()
+          .ApplyFiltering("Id=1/i")
+          .ToList();
+
+      Assert.Single(actual);
+   }
+
+   [Fact]
+   public void ApplyFiltering_WithCaseInsensitiveOperator_OnBoolProperty_ShouldNotThrow()
+   {
+      var actual = DataSource.AsQueryable()
+          .ApplyFiltering("IsActive=true/i")
+          .ToList();
+
+      Assert.Single(actual);
+   }
+
+   [Fact]
+   public void ApplyFiltering_WithGlobalCaseInsensitiveFiltering_OnNonStringProperties_ShouldNotThrow()
+   {
+      var mapper = new GridifyMapper<TestClass>(q => q.CaseInsensitiveFiltering = true)
+          .GenerateMappings();
+
+      var actual = DataSource.AsQueryable()
+          .ApplyFiltering($"MyGuid={TestGuid}", mapper)
+          .ToList();
+
+      Assert.Single(actual);
+   }
+}


### PR DESCRIPTION
# Description

Restrict case-insensitive filtering to string properties when using comparison operators. Previously the /i operator path had no type guard unlike the global CaseInsensitiveFiltering path, causing ToLower to be applied to non-string types (Guid, int, bool) and throwing at runtime.

Adds tests covering Guid, int, and bool with both /i and global config.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
