### PR TITLE
feat(select): add field projection (Select) support

### DIFF
--- a/docs/pages/guide/extensions.md
+++ b/docs/pages/guide/extensions.md
@@ -77,3 +77,41 @@ Like [ApplyFilteringOrderingPaging](#applyfilteringorderingpaging), but it retur
 
 This is an all-in-one method. It accepts `IGridifyQuery`, applies filtering, ordering, and paging, and returns a `Paging<T>` object.
 This method is optimized for use with any grid component.
+
+## ApplySelect
+
+Use this method to apply **field projection** to an `IQueryable` collection or `DbSet`. Each item in the result contains only the requested fields.
+
+``` csharp
+var query = personsRepo.ApplySelect("name,age,address.city");
+```
+
+This is roughly equivalent to the following LINQ query:
+
+``` csharp
+var query = personsRepo.Select(p => new { p.Name, p.Age, Address = new { p.Address.City } });
+```
+
+Each item is a runtime-emitted type with the requested properties. Under EF Core this translates to a column-pruned `SELECT` that reads only the requested columns. If the select string is null or empty, the method is a no-op cast (`IQueryable<T>` → `IQueryable<object>`).
+
+There is also an overload that accepts `IGridifySelecting` (which `GridifyQuery` implements):
+
+``` csharp
+var gq = new GridifyQuery { Select = "name,age" };
+var query = personsRepo.ApplySelect(gq);
+```
+
+Check out the [Selecting](./gridifyQuery.md#selecting) section for more information.
+
+## GridifySelect
+
+Like [Gridify](#gridify) but applies the `Select` projection at the end. Returns `Paging<object>` whose data items contain only the requested fields. If `Select` is null or empty, items are boxed instances of the source type.
+
+``` csharp
+var gq = new GridifyQuery { Filter = "age>18", OrderBy = "name", Select = "name,age" };
+Paging<object> result = personsRepo.GridifySelect(gq);
+```
+
+## GridifyQueryableSelect
+
+Like [GridifyQueryable](#gridifyqueryable) but with projection applied. Returns `QueryablePaging<object>`.

--- a/docs/pages/guide/gridifyQuery.md
+++ b/docs/pages/guide/gridifyQuery.md
@@ -1,6 +1,6 @@
 # GridifyQuery
 
-`GridifyQuery` is a simple class for configuring Filtering, Ordering and Paging.
+`GridifyQuery` is a simple class for configuring Filtering, Ordering, and Paging.
 
 ``` csharp
 var gq = new GridifyQuery()
@@ -15,8 +15,7 @@ var gq = new GridifyQuery()
 Paging<Person> result = personsRepo.Gridify(gq);
 ```
 
-Here’s an updated version of the `IsValid` section you can drop into the docs.
-
+`GridifyQuery` also has an optional `Select` property for field projection — see [Selecting](#selecting) below.
 
 ## IsValid
 
@@ -102,6 +101,54 @@ Notes:
 
 * Empty or null `Filter` values are considered valid and return `true`.
 * The “old” overloads (`IsValid<T>()` and `IsValid(mapper)`) remain and now also benefit from the improved value-type validation; they just don’t expose the error details.
+* If `Select` is set, `IsValid` also validates each requested path against the mapper.
+
+## Selecting
+
+The `Select` property picks a subset of fields to project. Each projected item is a runtime-emitted type containing only the requested properties. Under Entity Framework Core this translates to column-pruned SQL.
+
+``` csharp
+var gq = new GridifyQuery()
+{
+    Filter = "age>18",
+    OrderBy = "name",
+    Page = 1,
+    PageSize = 20,
+    Select = "name,age,address.city"
+};
+
+Paging<object> result = dbContext.People.GridifySelect(gq);
+```
+
+`GridifySelect` is the projecting counterpart of `Gridify`: filter, order, page, and project in one call. If `Select` is null or empty, items remain boxed instances of the source type.
+
+Dotted paths produce nested objects, and one level of collection projection is supported:
+
+``` csharp
+// nested object — result: { name, address: { city } }
+"name,address.city"
+
+// collection element — result: { name, orders: [ { amount } ] }
+"name,orders.amount"
+```
+
+Two-level collection nesting (e.g. `orders.items.price`) throws `GridifySelectException`.
+
+To validate a `Select` string in isolation, cast to `IGridifySelecting` and call `IsValidSelect`:
+
+``` csharp
+IGridifySelecting s = new GridifyQuery { Select = "name,doesNotExist" };
+bool ok = s.IsValidSelect<Person>(out var errors);
+
+// ok == false
+// errors contains "Field 'doesNotExist' is not mapped"
+```
+
+By default, unmapped fields cause validation to fail and projection to throw. Set `IgnoreNotMappedFields = true` on the mapper to silently drop them.
+
+::: warning
+Field projection is not supported under **NativeAOT** (tracked at [#140](https://github.com/alirezanet/Gridify/issues/140)), and `Gridify.Elasticsearch` does not yet implement `Select`.
+:::
 
 ## GetFilteringExpression
 

--- a/docs/pages/guide/queryBuilder.md
+++ b/docs/pages/guide/queryBuilder.md
@@ -25,6 +25,9 @@ The `QueryBuilder` class is useful when you want to manually build your query or
 | BuildWithPagingCompiled  | Compiles the expressions and returns a delegate for applying filtering, ordering, and paging to an enumerable collection that returns paging result |
 | BuildWithQueryablePaging | Applies filtering, ordering, and paging to a context and returns a queryable paging result                                                        |
 | Evaluate                 | Directly evaluates a context to check if all conditions are valid                                                                                 |
+| AddSelect                | Configures a field projection (Select) string. Has no effect on the typed Build* family                                                           |
+| BuildSelect              | Applies filtering, ordering, paging, and projection to a context; returns IQueryable&lt;object&gt;                                                |
+| BuildSelectWithPaging    | Applies filtering, ordering, paging, and projection to a context; returns a paging result of object                                               |
 
 ``` csharp
 var builder = new QueryBuilder<Person>()
@@ -126,4 +129,22 @@ var builder = new QueryBuilder<User>()
 
 var result = builder.Build(users.AsQueryable());
 ```
+
+## AddSelect
+
+The `AddSelect` method configures a [field projection](./gridifyQuery.md#selecting) string. It has no effect on the typed `Build*` family — only the `BuildSelect*` family applies it, returning `IQueryable<object>` or `Paging<object>` whose items contain only the requested fields.
+
+``` csharp
+var builder = new QueryBuilder<Person>()
+    .AddCondition("age>18")
+    .AddOrderBy("name")
+    .ConfigurePaging(0, 20)
+    .AddSelect("name,age,address.city");
+
+Paging<object> result = builder.BuildSelectWithPaging(persons);
+```
+
+If `AddSelect` is not called (or the configured string is null or empty), `BuildSelect` is a no-op cast — items are boxed instances of the source type.
+
+Check out the [Selecting](./gridifyQuery.md#selecting) section for more information.
 

--- a/src/Gridify/Builder/SelectExpressionBuilder.cs
+++ b/src/Gridify/Builder/SelectExpressionBuilder.cs
@@ -164,23 +164,27 @@ internal static class SelectExpressionBuilder<T>
       foreach (var group in groups)
       {
          var first = group.First();
-         var firstSegmentExpr = ExtractFirstSegmentExpr(first.Body, rootParam);
-         var firstSegmentType = firstSegmentExpr.Type;
 
-         // Leaf: only this single segment.
+         // Leaf: only this single segment. Use the mapper's resolved body directly so
+         // single-field aliases that resolve to nested values (e.g. childName → x.ChildClass.Name)
+         // or to collection projections (e.g. tags → x.Children.Select(c => c.Name)) project the
+         // resolved leaf, not the extracted first root segment.
          var allSingleSegment = group.All(p => p.Segments.Count == 1);
          if (allSingleSegment)
          {
             shape.Children.Add(new SelectNode
             {
                Name = group.Key,
-               Accessor = Expression.Lambda(firstSegmentExpr, rootParam),
-               ResultType = firstSegmentType
+               Accessor = Expression.Lambda(first.Body, rootParam),
+               ResultType = first.LeafType
             });
             continue;
          }
 
-         // Nested or collection.
+         // Nested or collection: group by the first root segment so multiple child paths
+         // (e.g. childClass.name, childClass.age) hang off one parent node.
+         var firstSegmentExpr = ExtractFirstSegmentExpr(first.Body, rootParam);
+         var firstSegmentType = firstSegmentExpr.Type;
          var isCollection = TryGetEnumerableElementType(firstSegmentType, out var elementType) && firstSegmentType != typeof(string);
          var childSourceType = isCollection ? elementType! : firstSegmentType;
          var childParam = Expression.Parameter(childSourceType, "y");

--- a/src/Gridify/Builder/SelectExpressionBuilder.cs
+++ b/src/Gridify/Builder/SelectExpressionBuilder.cs
@@ -1,0 +1,310 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Gridify.Syntax;
+
+namespace Gridify.Builder;
+
+internal static class SelectExpressionBuilder<T>
+{
+   public static Expression<Func<T, object>> Build(string select, IGridifyMapper<T> mapper)
+   {
+      var paths = SelectTokenizer.Parse(select);
+      if (paths.Count == 0)
+         throw new GridifySelectException("Select string is empty.");
+
+      var ignoreUnmapped = mapper.Configuration.IgnoreNotMappedFields;
+      var rootParam = Expression.Parameter(typeof(T), "x");
+
+      var resolved = new List<ResolvedPath>(paths.Count);
+      foreach (var path in paths)
+      {
+         try
+         {
+            var rp = ResolvePath(path, rootParam, mapper);
+            if (rp != null) resolved.Add(rp);
+         }
+         catch (GridifySelectException) when (ignoreUnmapped)
+         {
+            // skip silently
+         }
+      }
+
+      if (resolved.Count == 0)
+         throw new GridifySelectException("Select produced no fields.");
+
+      var nameComparer = mapper.Configuration.CaseSensitive
+         ? StringComparer.Ordinal
+         : StringComparer.OrdinalIgnoreCase;
+      var rootShape = BuildShape(typeof(T), resolved, rootParam, nameComparer);
+      var rootType = SelectTypeFactory.GetOrCreate(rootShape);
+
+      var memberInit = BuildMemberInitFromExpression(rootType, rootShape, rootParam);
+      var body = Expression.Convert(memberInit, typeof(object));
+      return Expression.Lambda<Func<T, object>>(body, rootParam);
+   }
+
+   private sealed class ResolvedPath
+   {
+      public IReadOnlyList<string> Segments { get; set; } = null!;
+      public Expression Body { get; set; } = null!;
+      public Type LeafType { get; set; } = null!;
+   }
+
+   private static ResolvedPath? ResolvePath(string path, ParameterExpression rootParam, IGridifyMapper<T> mapper)
+   {
+      // (a) Try full-path mapper key.
+      if (mapper.HasMap(path))
+      {
+         var mapExp = mapper.GetExpression(path);
+         var mapBody = StripConvert(mapExp.Body);
+         var rebound = ReplaceParameter(mapBody, mapExp.Parameters[0], rootParam);
+         return new ResolvedPath
+         {
+            Segments = path.Split('.'),
+            Body = rebound,
+            LeafType = rebound.Type
+         };
+      }
+
+      // (b)/(c) Try progressively shorter prefixes; resolve remaining segments by Expression.Property walks.
+      var segments = path.Split('.');
+      for (var prefixLen = segments.Length - 1; prefixLen >= 1; prefixLen--)
+      {
+         var prefix = string.Join(".", segments.Take(prefixLen));
+         if (!mapper.HasMap(prefix)) continue;
+
+         var mapExp = mapper.GetExpression(prefix);
+         var mapBody = StripConvert(mapExp.Body);
+         var rebound = ReplaceParameter(mapBody, mapExp.Parameters[0], rootParam);
+         var current = rebound;
+
+         for (var i = prefixLen; i < segments.Length; i++)
+            current = WalkSegment(current, segments[i]);
+
+         return new ResolvedPath
+         {
+            Segments = segments,
+            Body = current,
+            LeafType = current.Type
+         };
+      }
+
+      // (d) No mapper key matched any prefix — try resolving directly off T as a last resort.
+      try
+      {
+         Expression current = rootParam;
+         foreach (var seg in segments)
+            current = WalkSegment(current, seg);
+         return new ResolvedPath
+         {
+            Segments = segments,
+            Body = current,
+            LeafType = current.Type
+         };
+      }
+      catch (GridifySelectException)
+      {
+         // Preserve actionable messages from WalkSegment (e.g. multi-level collection).
+         throw;
+      }
+      catch
+      {
+         throw new GridifySelectException($"Field '{path}' is not mapped");
+      }
+   }
+
+   private static Expression WalkSegment(Expression current, string segment)
+   {
+      // If current is already a collection, deeper nesting is not supported.
+      if (TryGetEnumerableElementType(current.Type, out _) && current.Type != typeof(string))
+      {
+         throw new GridifySelectException(
+            $"Path projects through more than one collection level (segment '{segment}')");
+      }
+
+      var prop = current.Type.GetProperty(segment, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+      if (prop == null)
+         throw new GridifySelectException($"Path is not a property of type '{current.Type.Name}': '{segment}'");
+
+      return Expression.Property(current, prop);
+   }
+
+   private static SelectShape BuildShape(Type sourceType, List<ResolvedPath> paths, ParameterExpression rootParam, StringComparer nameComparer)
+   {
+      var shape = new SelectShape { SourceType = sourceType };
+      var groups = paths
+         .GroupBy(p => p.Segments[0], nameComparer)
+         .ToList();
+
+      foreach (var group in groups)
+      {
+         var first = group.First();
+         var firstSegmentExpr = ExtractFirstSegmentExpr(first.Body, rootParam);
+         var firstSegmentType = firstSegmentExpr.Type;
+
+         // Leaf: only this single segment.
+         var allSingleSegment = group.All(p => p.Segments.Count == 1);
+         if (allSingleSegment)
+         {
+            shape.Children.Add(new SelectNode
+            {
+               Name = group.Key,
+               Accessor = Expression.Lambda(firstSegmentExpr, rootParam),
+               ResultType = firstSegmentType
+            });
+            continue;
+         }
+
+         // Nested or collection.
+         var isCollection = TryGetEnumerableElementType(firstSegmentType, out var elementType) && firstSegmentType != typeof(string);
+         var childSourceType = isCollection ? elementType! : firstSegmentType;
+         var childParam = Expression.Parameter(childSourceType, "y");
+
+         // Build child paths re-anchored at childParam.
+         var childPaths = group
+            .Where(p => p.Segments.Count > 1)
+            .Select(p => RebaseToChild(p, childParam))
+            .ToList();
+
+         var childShape = BuildShape(childSourceType, childPaths, childParam, nameComparer);
+         var emittedChildType = SelectTypeFactory.GetOrCreate(childShape);
+
+         shape.Children.Add(new SelectNode
+         {
+            Name = group.Key,
+            Accessor = Expression.Lambda(firstSegmentExpr, rootParam),
+            ResultType = emittedChildType,
+            ChildShape = childShape,
+            IsCollection = isCollection,
+            ElementType = elementType
+         });
+      }
+
+      return shape;
+   }
+
+   /// <summary>
+   /// Extracts the first-segment expression from a body expression.
+   /// Unwraps Select/SelectMany calls to reach the source, then walks inward
+   /// through MemberExpression chains to find the property directly on <paramref name="rootParam"/>.
+   /// </summary>
+   private static Expression ExtractFirstSegmentExpr(Expression body, ParameterExpression rootParam)
+   {
+      var current = body;
+
+      // Unwrap Select/SelectMany calls to get to the source collection expression.
+      while (current is MethodCallExpression mce
+             && (mce.Method.Name == "Select" || mce.Method.Name == "SelectMany")
+             && mce.Arguments.Count >= 1)
+      {
+         current = mce.Arguments[0];
+      }
+
+      // Walk MemberExpression chain inward to find the member directly on rootParam.
+      while (current is MemberExpression me)
+      {
+         if (me.Expression == rootParam)
+            return me;
+         current = me.Expression!;
+      }
+
+      return body; // fallback for unusual expressions
+   }
+
+   private static ResolvedPath RebaseToChild(ResolvedPath original, ParameterExpression childParam)
+   {
+      // Reconstruct the body by walking childParam.<segments[1..]>.
+      Expression current = childParam;
+      for (var i = 1; i < original.Segments.Count; i++)
+         current = WalkSegment(current, original.Segments[i]);
+
+      return new ResolvedPath
+      {
+         Segments = original.Segments.Skip(1).ToArray(),
+         Body = current,
+         LeafType = current.Type
+      };
+   }
+
+   private static MemberInitExpression BuildMemberInitFromExpression(Type emittedType, SelectShape shape, Expression nestedSource)
+   {
+      var bindings = new List<MemberBinding>();
+      foreach (var child in shape.Children)
+      {
+         var prop = emittedType.GetProperty(child.Name)
+            ?? throw new InvalidOperationException($"Emitted property '{child.Name}' missing on {emittedType.Name}");
+
+         Expression value;
+         if (child.ChildShape == null)
+         {
+            // Leaf: substitute nestedSource in place of the accessor's parameter.
+            value = ReplaceParameter(child.Accessor.Body, child.Accessor.Parameters[0], nestedSource);
+         }
+         else if (child.IsCollection)
+         {
+            // Build inner MemberInit lambda over element param.
+            var elementType = child.ElementType!;
+            var elementParam = Expression.Parameter(elementType, "e");
+            var innerInit = BuildMemberInitFromExpression(child.ResultType, child.ChildShape, elementParam);
+            var innerLambda = Expression.Lambda(innerInit, elementParam);
+
+            var collectionExpr = ReplaceParameter(child.Accessor.Body, child.Accessor.Parameters[0], nestedSource);
+            var selectMethod = typeof(Enumerable).GetMethods()
+               .First(m => m.Name == nameof(Enumerable.Select)
+                  && m.GetParameters().Length == 2
+                  && m.GetParameters()[1].ParameterType.GetGenericArguments().Length == 2)
+               .MakeGenericMethod(elementType, child.ResultType);
+            value = Expression.Call(selectMethod, collectionExpr, innerLambda);
+         }
+         else
+         {
+            // Nested object: build inner MemberInit using the nested source expression.
+            var deeperSource = ReplaceParameter(child.Accessor.Body, child.Accessor.Parameters[0], nestedSource);
+            value = BuildMemberInitFromExpression(child.ResultType, child.ChildShape, deeperSource);
+         }
+
+         bindings.Add(Expression.Bind(prop, value));
+      }
+      return Expression.MemberInit(Expression.New(emittedType), bindings);
+   }
+
+   private static Expression StripConvert(Expression e)
+   {
+      while (e is UnaryExpression u && (u.NodeType == ExpressionType.Convert || u.NodeType == ExpressionType.ConvertChecked))
+         e = u.Operand;
+      return e;
+   }
+
+   private static Expression ReplaceParameter(Expression body, ParameterExpression oldParam, Expression newExpr)
+   {
+      return new ParameterReplacer(oldParam, newExpr).Visit(body)!;
+   }
+
+   private sealed class ParameterReplacer(ParameterExpression oldParam, Expression newExpr) : ExpressionVisitor
+   {
+      protected override Expression VisitParameter(ParameterExpression node) =>
+         node == oldParam ? newExpr : base.VisitParameter(node);
+   }
+
+   private static bool TryGetEnumerableElementType(Type type, out Type? elementType)
+   {
+      if (type.IsArray)
+      {
+         elementType = type.GetElementType();
+         return true;
+      }
+      foreach (var i in type.GetInterfaces().Concat(new[] { type }))
+      {
+         if (i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+         {
+            elementType = i.GetGenericArguments()[0];
+            return true;
+         }
+      }
+      elementType = null;
+      return false;
+   }
+}

--- a/src/Gridify/Builder/SelectExpressionBuilder.cs
+++ b/src/Gridify/Builder/SelectExpressionBuilder.cs
@@ -16,6 +16,7 @@ internal static class SelectExpressionBuilder<T>
          throw new GridifySelectException("Select string is empty.");
 
       var ignoreUnmapped = mapper.Configuration.IgnoreNotMappedFields;
+      var caseInsensitive = !mapper.Configuration.CaseSensitive;
       var rootParam = Expression.Parameter(typeof(T), "x");
 
       var resolved = new List<ResolvedPath>(paths.Count);
@@ -23,7 +24,7 @@ internal static class SelectExpressionBuilder<T>
       {
          try
          {
-            var rp = ResolvePath(path, rootParam, mapper);
+            var rp = ResolvePath(path, rootParam, mapper, caseInsensitive);
             if (rp != null) resolved.Add(rp);
          }
          catch (GridifySelectException) when (ignoreUnmapped)
@@ -35,10 +36,8 @@ internal static class SelectExpressionBuilder<T>
       if (resolved.Count == 0)
          throw new GridifySelectException("Select produced no fields.");
 
-      var nameComparer = mapper.Configuration.CaseSensitive
-         ? StringComparer.Ordinal
-         : StringComparer.OrdinalIgnoreCase;
-      var rootShape = BuildShape(typeof(T), resolved, rootParam, nameComparer);
+      var nameComparer = caseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+      var rootShape = BuildShape(typeof(T), resolved, rootParam, nameComparer, caseInsensitive);
       var rootType = SelectTypeFactory.GetOrCreate(rootShape);
 
       var memberInit = BuildMemberInitFromExpression(rootType, rootShape, rootParam);
@@ -53,7 +52,7 @@ internal static class SelectExpressionBuilder<T>
       public Type LeafType { get; set; } = null!;
    }
 
-   private static ResolvedPath? ResolvePath(string path, ParameterExpression rootParam, IGridifyMapper<T> mapper)
+   private static ResolvedPath? ResolvePath(string path, ParameterExpression rootParam, IGridifyMapper<T> mapper, bool caseInsensitive)
    {
       // (a) Try full-path mapper key.
       if (mapper.HasMap(path))
@@ -82,7 +81,7 @@ internal static class SelectExpressionBuilder<T>
          var current = rebound;
 
          for (var i = prefixLen; i < segments.Length; i++)
-            current = WalkSegment(current, segments[i]);
+            current = WalkSegment(current, segments[i], caseInsensitive);
 
          return new ResolvedPath
          {
@@ -92,31 +91,11 @@ internal static class SelectExpressionBuilder<T>
          };
       }
 
-      // (d) No mapper key matched any prefix — try resolving directly off T as a last resort.
-      try
-      {
-         Expression current = rootParam;
-         foreach (var seg in segments)
-            current = WalkSegment(current, seg);
-         return new ResolvedPath
-         {
-            Segments = segments,
-            Body = current,
-            LeafType = current.Type
-         };
-      }
-      catch (GridifySelectException)
-      {
-         // Preserve actionable messages from WalkSegment (e.g. multi-level collection).
-         throw;
-      }
-      catch
-      {
-         throw new GridifySelectException($"Field '{path}' is not mapped");
-      }
+      // No mapper key matched the full path or any prefix.
+      throw new GridifySelectException($"Field '{path}' is not mapped");
    }
 
-   private static Expression WalkSegment(Expression current, string segment)
+   private static Expression WalkSegment(Expression current, string segment, bool caseInsensitive)
    {
       // If current is already a collection, deeper nesting is not supported.
       if (TryGetEnumerableElementType(current.Type, out _) && current.Type != typeof(string))
@@ -125,14 +104,16 @@ internal static class SelectExpressionBuilder<T>
             $"Path projects through more than one collection level (segment '{segment}')");
       }
 
-      var prop = current.Type.GetProperty(segment, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+      var bindingFlags = BindingFlags.Public | BindingFlags.Instance;
+      if (caseInsensitive) bindingFlags |= BindingFlags.IgnoreCase;
+      var prop = current.Type.GetProperty(segment, bindingFlags);
       if (prop == null)
          throw new GridifySelectException($"Path is not a property of type '{current.Type.Name}': '{segment}'");
 
       return Expression.Property(current, prop);
    }
 
-   private static SelectShape BuildShape(Type sourceType, List<ResolvedPath> paths, ParameterExpression rootParam, StringComparer nameComparer)
+   private static SelectShape BuildShape(Type sourceType, List<ResolvedPath> paths, ParameterExpression rootParam, StringComparer nameComparer, bool caseInsensitive)
    {
       var shape = new SelectShape { SourceType = sourceType };
       var groups = paths
@@ -166,10 +147,10 @@ internal static class SelectExpressionBuilder<T>
          // Build child paths re-anchored at childParam.
          var childPaths = group
             .Where(p => p.Segments.Count > 1)
-            .Select(p => RebaseToChild(p, childParam))
+            .Select(p => RebaseToChild(p, childParam, caseInsensitive))
             .ToList();
 
-         var childShape = BuildShape(childSourceType, childPaths, childParam, nameComparer);
+         var childShape = BuildShape(childSourceType, childPaths, childParam, nameComparer, caseInsensitive);
          var emittedChildType = SelectTypeFactory.GetOrCreate(childShape);
 
          shape.Children.Add(new SelectNode
@@ -214,12 +195,12 @@ internal static class SelectExpressionBuilder<T>
       return body; // fallback for unusual expressions
    }
 
-   private static ResolvedPath RebaseToChild(ResolvedPath original, ParameterExpression childParam)
+   private static ResolvedPath RebaseToChild(ResolvedPath original, ParameterExpression childParam, bool caseInsensitive)
    {
       // Reconstruct the body by walking childParam.<segments[1..]>.
       Expression current = childParam;
       for (var i = 1; i < original.Segments.Count; i++)
-         current = WalkSegment(current, original.Segments[i]);
+         current = WalkSegment(current, original.Segments[i], caseInsensitive);
 
       return new ResolvedPath
       {

--- a/src/Gridify/Builder/SelectExpressionBuilder.cs
+++ b/src/Gridify/Builder/SelectExpressionBuilder.cs
@@ -16,7 +16,6 @@ internal static class SelectExpressionBuilder<T>
          throw new GridifySelectException("Select string is empty.");
 
       var ignoreUnmapped = mapper.Configuration.IgnoreNotMappedFields;
-      var caseInsensitive = !mapper.Configuration.CaseSensitive;
       var rootParam = Expression.Parameter(typeof(T), "x");
 
       var resolved = new List<ResolvedPath>(paths.Count);
@@ -24,7 +23,7 @@ internal static class SelectExpressionBuilder<T>
       {
          try
          {
-            var rp = ResolvePath(path, rootParam, mapper, caseInsensitive);
+            var rp = ResolvePath(path, rootParam, mapper);
             if (rp != null) resolved.Add(rp);
          }
          catch (GridifySelectFieldNotMappedException) when (ignoreUnmapped)
@@ -38,8 +37,7 @@ internal static class SelectExpressionBuilder<T>
       if (resolved.Count == 0)
          throw new GridifySelectException("Select produced no fields.");
 
-      var nameComparer = caseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
-      var rootShape = BuildShape(typeof(T), resolved, rootParam, nameComparer, caseInsensitive);
+      var rootShape = BuildShape(typeof(T), resolved, rootParam);
       var rootType = SelectTypeFactory.GetOrCreate(rootShape);
 
       var memberInit = BuildMemberInitFromExpression(rootType, rootShape, rootParam);
@@ -54,17 +52,19 @@ internal static class SelectExpressionBuilder<T>
       public Type LeafType { get; set; } = null!;
    }
 
-   private static ResolvedPath? ResolvePath(string path, ParameterExpression rootParam, IGridifyMapper<T> mapper, bool caseInsensitive)
+   private static ResolvedPath? ResolvePath(string path, ParameterExpression rootParam, IGridifyMapper<T> mapper)
    {
-      // (a) Try full-path mapper key.
+      // (a) Try full-path mapper key. Canonicalize to the mapper's stored "From" casing
+      // so case-only variants share one cached shape under case-insensitive mappers.
       if (mapper.HasMap(path))
       {
+         var canonical = mapper.GetGMap(path)!.From;
          var mapExp = mapper.GetExpression(path);
          var mapBody = StripConvert(mapExp.Body);
          var rebound = ReplaceParameter(mapBody, mapExp.Parameters[0], rootParam);
          return new ResolvedPath
          {
-            Segments = path.Split('.'),
+            Segments = canonical.Split('.'),
             Body = rebound,
             LeafType = rebound.Type
          };
@@ -77,17 +77,24 @@ internal static class SelectExpressionBuilder<T>
          var prefix = string.Join(".", segments.Take(prefixLen));
          if (!mapper.HasMap(prefix)) continue;
 
+         var canonicalSegments = new string[segments.Length];
+         var canonicalPrefixParts = mapper.GetGMap(prefix)!.From.Split('.');
+         Array.Copy(canonicalPrefixParts, canonicalSegments, prefixLen);
+
          var mapExp = mapper.GetExpression(prefix);
          var mapBody = StripConvert(mapExp.Body);
          var rebound = ReplaceParameter(mapBody, mapExp.Parameters[0], rootParam);
          var current = rebound;
 
          for (var i = prefixLen; i < segments.Length; i++)
-            current = WalkSegment(current, segments[i], caseInsensitive);
+         {
+            (current, var canonicalName) = WalkSegment(current, segments[i]);
+            canonicalSegments[i] = canonicalName;
+         }
 
          return new ResolvedPath
          {
-            Segments = segments,
+            Segments = canonicalSegments,
             Body = current,
             LeafType = current.Type
          };
@@ -106,7 +113,6 @@ internal static class SelectExpressionBuilder<T>
    /// </summary>
    internal static void ValidatePaths(IReadOnlyList<string> paths, IGridifyMapper<T> mapper, List<string> errors)
    {
-      var caseInsensitive = !mapper.Configuration.CaseSensitive;
       var ignoreUnmapped = mapper.Configuration.IgnoreNotMappedFields;
       var rootParam = Expression.Parameter(typeof(T), "x");
 
@@ -114,7 +120,7 @@ internal static class SelectExpressionBuilder<T>
       {
          try
          {
-            _ = ResolvePath(path, rootParam, mapper, caseInsensitive);
+            _ = ResolvePath(path, rootParam, mapper);
          }
          catch (GridifySelectFieldNotMappedException) when (ignoreUnmapped)
          {
@@ -127,7 +133,7 @@ internal static class SelectExpressionBuilder<T>
       }
    }
 
-   private static Expression WalkSegment(Expression current, string segment, bool caseInsensitive)
+   private static (Expression Expression, string CanonicalName) WalkSegment(Expression current, string segment)
    {
       // If current is already a collection, deeper nesting is not supported.
       if (TryGetEnumerableElementType(current.Type, out _) && current.Type != typeof(string))
@@ -136,20 +142,23 @@ internal static class SelectExpressionBuilder<T>
             $"Path projects through more than one collection level (segment '{segment}')");
       }
 
-      var bindingFlags = BindingFlags.Public | BindingFlags.Instance;
-      if (caseInsensitive) bindingFlags |= BindingFlags.IgnoreCase;
-      var prop = current.Type.GetProperty(segment, bindingFlags);
+      // CLR reflection is always case-insensitive: mapper.Configuration.CaseSensitive
+      // governs map-key matching, not CLR property lookup, and CLS-compliant types
+      // can't have two properties differing only by case.
+      const BindingFlags flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase;
+      var prop = current.Type.GetProperty(segment, flags);
       if (prop == null)
          throw new GridifySelectException($"Path is not a property of type '{current.Type.Name}': '{segment}'");
 
-      return Expression.Property(current, prop);
+      return (Expression.Property(current, prop), prop.Name);
    }
 
-   private static SelectShape BuildShape(Type sourceType, List<ResolvedPath> paths, ParameterExpression rootParam, StringComparer nameComparer, bool caseInsensitive)
+   private static SelectShape BuildShape(Type sourceType, List<ResolvedPath> paths, ParameterExpression rootParam)
    {
       var shape = new SelectShape { SourceType = sourceType };
+      // Segments are pre-canonicalized in ResolvePath, so Ordinal grouping suffices.
       var groups = paths
-         .GroupBy(p => p.Segments[0], nameComparer)
+         .GroupBy(p => p.Segments[0], StringComparer.Ordinal)
          .ToList();
 
       foreach (var group in groups)
@@ -179,10 +188,10 @@ internal static class SelectExpressionBuilder<T>
          // Build child paths re-anchored at childParam.
          var childPaths = group
             .Where(p => p.Segments.Count > 1)
-            .Select(p => RebaseToChild(p, childParam, caseInsensitive))
+            .Select(p => RebaseToChild(p, childParam))
             .ToList();
 
-         var childShape = BuildShape(childSourceType, childPaths, childParam, nameComparer, caseInsensitive);
+         var childShape = BuildShape(childSourceType, childPaths, childParam);
          var emittedChildType = SelectTypeFactory.GetOrCreate(childShape);
 
          shape.Children.Add(new SelectNode
@@ -227,12 +236,12 @@ internal static class SelectExpressionBuilder<T>
       return body; // fallback for unusual expressions
    }
 
-   private static ResolvedPath RebaseToChild(ResolvedPath original, ParameterExpression childParam, bool caseInsensitive)
+   private static ResolvedPath RebaseToChild(ResolvedPath original, ParameterExpression childParam)
    {
       // Reconstruct the body by walking childParam.<segments[1..]>.
       Expression current = childParam;
       for (var i = 1; i < original.Segments.Count; i++)
-         current = WalkSegment(current, original.Segments[i], caseInsensitive);
+         (current, _) = WalkSegment(current, original.Segments[i]);
 
       return new ResolvedPath
       {

--- a/src/Gridify/Builder/SelectExpressionBuilder.cs
+++ b/src/Gridify/Builder/SelectExpressionBuilder.cs
@@ -27,9 +27,11 @@ internal static class SelectExpressionBuilder<T>
             var rp = ResolvePath(path, rootParam, mapper, caseInsensitive);
             if (rp != null) resolved.Add(rp);
          }
-         catch (GridifySelectException) when (ignoreUnmapped)
+         catch (GridifySelectFieldNotMappedException) when (ignoreUnmapped)
          {
-            // skip silently
+            // Only "field not mapped" is silenced under IgnoreNotMappedFields.
+            // Structural errors (two-level collection, "not a property of type")
+            // still propagate so the caller learns the path is unprojectable.
          }
       }
 
@@ -92,7 +94,37 @@ internal static class SelectExpressionBuilder<T>
       }
 
       // No mapper key matched the full path or any prefix.
-      throw new GridifySelectException($"Field '{path}' is not mapped");
+      throw new GridifySelectFieldNotMappedException(path);
+   }
+
+   /// <summary>
+   /// Validator-only path resolution. Tokenized paths are resolved through the mapper
+   /// and per-path errors collected into <paramref name="errors"/>. Does not emit any
+   /// runtime types and does not build the projection lambda — the cache and IL
+   /// emission are deliberately skipped so that validating user input doesn't pollute
+   /// the <see cref="SelectTypeFactory"/> cache with single-field shapes.
+   /// </summary>
+   internal static void ValidatePaths(IReadOnlyList<string> paths, IGridifyMapper<T> mapper, List<string> errors)
+   {
+      var caseInsensitive = !mapper.Configuration.CaseSensitive;
+      var ignoreUnmapped = mapper.Configuration.IgnoreNotMappedFields;
+      var rootParam = Expression.Parameter(typeof(T), "x");
+
+      foreach (var path in paths)
+      {
+         try
+         {
+            _ = ResolvePath(path, rootParam, mapper, caseInsensitive);
+         }
+         catch (GridifySelectFieldNotMappedException) when (ignoreUnmapped)
+         {
+            // mapper will silently drop this at runtime; validator treats it as OK.
+         }
+         catch (GridifySelectException ex)
+         {
+            errors.Add(ex.Message);
+         }
+      }
    }
 
    private static Expression WalkSegment(Expression current, string segment, bool caseInsensitive)

--- a/src/Gridify/Builder/SelectShape.cs
+++ b/src/Gridify/Builder/SelectShape.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Gridify.Builder;
+
+/// <summary>
+/// Resolved tree of select paths. The root holds the source type T;
+/// each node represents one property on its parent type.
+/// </summary>
+internal sealed class SelectShape
+{
+   /// <summary>Type whose properties are described by <see cref="Children"/>.</summary>
+   public System.Type SourceType { get; set; } = null!;
+
+   public List<SelectNode> Children { get; } = new();
+}
+
+internal sealed class SelectNode
+{
+   /// <summary>Name as written by the user (used as the emitted property name).</summary>
+   public string Name { get; set; } = null!;
+
+   /// <summary>
+   /// Expression that, given a parameter of the parent's source type, produces this node's value.
+   /// For leaf nodes this is the resolved property/path expression.
+   /// For nested-object nodes this is the parent property access (e.g. p => p.Address);
+   /// the <see cref="ChildShape"/> describes how to project from there.
+   /// For collection nodes this is the collection access (e.g. p => p.Orders);
+   /// the <see cref="ChildShape"/> describes how to project each element.
+   /// </summary>
+   public LambdaExpression Accessor { get; set; } = null!;
+
+   /// <summary>The CLR type of the value this node ultimately produces (after projection).</summary>
+   public System.Type ResultType { get; set; } = null!;
+
+   /// <summary>Null for leaves; populated for nested-object and collection nodes.</summary>
+   public SelectShape? ChildShape { get; set; }
+
+   /// <summary>True when the parent's property is a collection and we project each element.</summary>
+   public bool IsCollection { get; set; }
+
+   /// <summary>For collection nodes, the element type (T in IEnumerable&lt;T&gt;).</summary>
+   public System.Type? ElementType { get; set; }
+}

--- a/src/Gridify/Builder/SelectTypeFactory.cs
+++ b/src/Gridify/Builder/SelectTypeFactory.cs
@@ -10,6 +10,19 @@ using System.Threading;
 
 namespace Gridify.Builder;
 
+/// <summary>
+/// Emits and caches runtime CLR types matching a <see cref="SelectShape"/> so each unique
+/// projection shape is materialized as exactly one type per process.
+/// </summary>
+/// <remarks>
+/// The cache is process-wide and unbounded — emitted types live for the lifetime of the
+/// dynamic assembly. For typical use (a finite set of select strings per endpoint) the cache
+/// is naturally bounded. If select strings can come from untrusted input and produce
+/// arbitrarily many distinct shapes, validate / restrict the input before calling
+/// <see cref="GridifyExtensions.ApplySelect{T}(System.Linq.IQueryable{T}, string?, IGridifyMapper{T}?)"/>
+/// (e.g. via <see cref="GridifyExtensions.IsValidSelect{T}(IGridifySelecting, IGridifyMapper{T})"/>)
+/// to keep cache growth predictable.
+/// </remarks>
 internal static class SelectTypeFactory
 {
    private static readonly ConcurrentDictionary<string, Type> Cache = new();

--- a/src/Gridify/Builder/SelectTypeFactory.cs
+++ b/src/Gridify/Builder/SelectTypeFactory.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+
+namespace Gridify.Builder;
+
+internal static class SelectTypeFactory
+{
+   private static readonly ConcurrentDictionary<string, Type> Cache = new();
+   private static readonly object EmissionLock = new();
+
+   private static ModuleBuilder? _module;
+
+   private static ModuleBuilder Module
+   {
+      get
+      {
+         if (_module != null) return _module;
+         lock (EmissionLock)
+         {
+            if (_module != null) return _module;
+            var asmName = new AssemblyName("Gridify.Dynamic");
+            var asm = AssemblyBuilder.DefineDynamicAssembly(asmName, AssemblyBuilderAccess.Run);
+            _module = asm.DefineDynamicModule("Gridify.Dynamic");
+            return _module;
+         }
+      }
+   }
+
+   public static Type GetOrCreate(SelectShape shape)
+   {
+#if NET8_0_OR_GREATER
+      if (!RuntimeFeature.IsDynamicCodeSupported)
+         throw new GridifySelectException(
+            "Select requires JIT support; not available under NativeAOT. Track issue #140.");
+#endif
+
+      var signature = BuildSignature(shape);
+
+      if (Cache.TryGetValue(signature, out var existing))
+         return existing;
+
+      lock (EmissionLock)
+      {
+         if (Cache.TryGetValue(signature, out existing))
+            return existing;
+
+         var emitted = EmitType(shape, signature);
+         Cache[signature] = emitted;
+         return emitted;
+      }
+   }
+
+   private static string BuildSignature(SelectShape shape)
+   {
+      var sb = new StringBuilder();
+      sb.Append(shape.SourceType.FullName ?? shape.SourceType.Name);
+      sb.Append('|');
+      foreach (var child in shape.Children.OrderBy(c => c.Name, StringComparer.Ordinal))
+      {
+         sb.Append(child.Name);
+         sb.Append(':');
+         sb.Append(child.ResultType.FullName ?? child.ResultType.Name);
+         if (child.IsCollection) sb.Append("[]");
+         if (child.ChildShape != null)
+         {
+            sb.Append('{');
+            sb.Append(BuildSignature(child.ChildShape));
+            sb.Append('}');
+         }
+         sb.Append(';');
+      }
+      return sb.ToString();
+   }
+
+   private static int _nameCounter;
+
+   private static Type EmitType(SelectShape shape, string signature)
+   {
+      var hash = ((uint)signature.GetHashCode()).ToString("X");
+      var counter = Interlocked.Increment(ref _nameCounter);
+      var typeName = "Gridify_Select_" + hash + "_" + counter.ToString("X");
+
+      var tb = Module.DefineType(
+         typeName,
+         TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Sealed |
+         TypeAttributes.AutoClass | TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit);
+
+      var compilerGeneratedCtor = typeof(CompilerGeneratedAttribute).GetConstructor(Type.EmptyTypes)!;
+      tb.SetCustomAttribute(new CustomAttributeBuilder(compilerGeneratedCtor, Array.Empty<object>()));
+
+      foreach (var child in shape.Children)
+      {
+         var propType = child.IsCollection
+            ? typeof(IEnumerable<>).MakeGenericType(child.ResultType)
+            : child.ResultType;
+         AddAutoProperty(tb, child.Name, propType);
+      }
+
+      // Parameterless constructor — required for Expression.MemberInit + EF Core's translation.
+      tb.DefineDefaultConstructor(MethodAttributes.Public);
+
+#if NETSTANDARD2_0
+      return tb.CreateTypeInfo()!.AsType();
+#else
+      return tb.CreateType()!;
+#endif
+   }
+
+   private static void AddAutoProperty(TypeBuilder tb, string name, Type propType)
+   {
+      var field = tb.DefineField("_" + name, propType, FieldAttributes.Private);
+      var prop = tb.DefineProperty(name, PropertyAttributes.HasDefault, propType, null);
+
+      var getter = tb.DefineMethod(
+         "get_" + name,
+         MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
+         propType, Type.EmptyTypes);
+      var getIl = getter.GetILGenerator();
+      getIl.Emit(OpCodes.Ldarg_0);
+      getIl.Emit(OpCodes.Ldfld, field);
+      getIl.Emit(OpCodes.Ret);
+
+      var setter = tb.DefineMethod(
+         "set_" + name,
+         MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
+         null, new[] { propType });
+      var setIl = setter.GetILGenerator();
+      setIl.Emit(OpCodes.Ldarg_0);
+      setIl.Emit(OpCodes.Ldarg_1);
+      setIl.Emit(OpCodes.Stfld, field);
+      setIl.Emit(OpCodes.Ret);
+
+      prop.SetGetMethod(getter);
+      prop.SetSetMethod(setter);
+   }
+}

--- a/src/Gridify/Exceptions/GridifySelectException.cs
+++ b/src/Gridify/Exceptions/GridifySelectException.cs
@@ -1,0 +1,5 @@
+using System;
+
+namespace Gridify;
+
+public class GridifySelectException(string message) : Exception(message);

--- a/src/Gridify/Exceptions/GridifySelectFieldNotMappedException.cs
+++ b/src/Gridify/Exceptions/GridifySelectFieldNotMappedException.cs
@@ -1,0 +1,7 @@
+namespace Gridify;
+
+public class GridifySelectFieldNotMappedException(string field)
+   : GridifySelectException($"Field '{field}' is not mapped")
+{
+   public string Field { get; } = field;
+}

--- a/src/Gridify/GridifyExtensions.cs
+++ b/src/Gridify/GridifyExtensions.cs
@@ -255,6 +255,24 @@ public static partial class GridifyExtensions
          : new LinqSortingQueryBuilder<T>(mapper).ProcessOrdering(query, orderBy, startWithThenBy);
    }
 
+   /// <summary>
+   /// Projects the queryable to a sequence of runtime-emitted types containing only the
+   /// fields named in <paramref name="select"/> (e.g. <c>"name,address.city,orders.amount"</c>).
+   /// Under EF Core this translates to a column-pruned SQL <c>SELECT</c>.
+   /// </summary>
+   /// <param name="query">The source queryable.</param>
+   /// <param name="select">
+   /// A comma-separated list of field paths. Dotted paths produce nested objects; one level
+   /// of collection projection is supported. If null or whitespace, this method is a no-op
+   /// cast (<c>IQueryable&lt;T&gt;</c> → <c>IQueryable&lt;object&gt;</c>) and no projection is applied.
+   /// </param>
+   /// <param name="mapper">
+   /// Optional mapper. If omitted, an auto-generated mapper is used.
+   /// </param>
+   /// <exception cref="GridifySelectException">
+   /// Thrown for invalid syntax, unmapped fields (unless <c>IgnoreNotMappedFields</c> is set),
+   /// two-level collection nesting, or under NativeAOT (where dynamic code is unsupported).
+   /// </exception>
    public static IQueryable<object> ApplySelect<T>(this IQueryable<T> query, string? select, IGridifyMapper<T>? mapper = null)
    {
       if (string.IsNullOrWhiteSpace(select))
@@ -265,6 +283,11 @@ public static partial class GridifyExtensions
       return query.Select(lambda);
    }
 
+   /// <summary>
+   /// Overload that reads the select string from <see cref="IGridifySelecting.Select"/>.
+   /// If <paramref name="selecting"/> is null or its <c>Select</c> string is null/whitespace,
+   /// this method is a no-op cast.
+   /// </summary>
    public static IQueryable<object> ApplySelect<T>(this IQueryable<T> query, IGridifySelecting? selecting, IGridifyMapper<T>? mapper = null)
    {
       if (selecting == null) return query.Cast<object>();

--- a/src/Gridify/GridifyExtensions.cs
+++ b/src/Gridify/GridifyExtensions.cs
@@ -295,9 +295,10 @@ public static partial class GridifyExtensions
    }
 
    /// <summary>
-   /// Validates Filter and/or OrderBy with Mappings
+   /// Validates Filter, OrderBy, and (when the query implements <see cref="IGridifySelecting"/>)
+   /// the Select string against the configured mappings.
    /// </summary>
-   /// <param name="gridifyQuery">gridify query with (Filter or OrderBy) </param>
+   /// <param name="gridifyQuery">gridify query with Filter, OrderBy, and optionally Select</param>
    /// <param name="mapper">the gridify mapper that you want to use with, this is optional</param>
    /// <typeparam name="T"></typeparam>
    /// <returns></returns>

--- a/src/Gridify/GridifyExtensions.cs
+++ b/src/Gridify/GridifyExtensions.cs
@@ -255,18 +255,20 @@ public static partial class GridifyExtensions
          : new LinqSortingQueryBuilder<T>(mapper).ProcessOrdering(query, orderBy, startWithThenBy);
    }
 
-   public static IQueryable<object> ApplySelect<T>(this IQueryable<T> query, string props, IGridifyMapper<T>? mapper = null)
+   public static IQueryable<object> ApplySelect<T>(this IQueryable<T> query, string? select, IGridifyMapper<T>? mapper = null)
    {
-      if (string.IsNullOrWhiteSpace(props))
-         return (IQueryable<object>)query;
+      if (string.IsNullOrWhiteSpace(select))
+         return query.Cast<object>();
 
-      mapper ??= new GridifyMapper<T>(true);
+      mapper ??= new GridifyMapper<T>(autoGenerateMappings: true, maxNestingDepth: 1);
+      var lambda = Builder.SelectExpressionBuilder<T>.Build(select!, mapper);
+      return query.Select(lambda);
+   }
 
-      var exp = mapper.GetExpression(props);
-      var result = query.Select(exp);
-
-
-      return result;
+   public static IQueryable<object> ApplySelect<T>(this IQueryable<T> query, IGridifySelecting? selecting, IGridifyMapper<T>? mapper = null)
+   {
+      if (selecting == null) return query.Cast<object>();
+      return query.ApplySelect(selecting.Select, mapper);
    }
 
    /// <summary>

--- a/src/Gridify/GridifyExtensions.cs
+++ b/src/Gridify/GridifyExtensions.cs
@@ -280,8 +280,64 @@ public static partial class GridifyExtensions
    /// <returns></returns>
    public static bool IsValid<T>(this IGridifyQuery gridifyQuery, IGridifyMapper<T>? mapper = null)
    {
-      return ((IGridifyFiltering)gridifyQuery).IsValid(mapper) &&
-             ((IGridifyOrdering)gridifyQuery).IsValid(mapper);
+      var ok = ((IGridifyFiltering)gridifyQuery).IsValid(mapper) &&
+               ((IGridifyOrdering)gridifyQuery).IsValid(mapper);
+      if (gridifyQuery is IGridifySelecting s)
+         ok = ok && s.IsValidSelect(mapper);
+      return ok;
+   }
+
+   /// <summary>
+   /// Validates a Select string against the mapper. Returns true if the Select string is
+   /// null/empty or every requested path is resolvable (and, by default, mapped).
+   /// </summary>
+   /// <remarks>
+   /// Named <c>IsValidSelect</c> rather than <c>IsValid</c> because <see cref="GridifyQuery"/>
+   /// implements both <see cref="IGridifyQuery"/> and <see cref="IGridifySelecting"/>; an
+   /// <c>IsValid</c> extension on each interface would make calls on a <c>GridifyQuery</c>
+   /// instance ambiguous.
+   /// </remarks>
+   public static bool IsValidSelect<T>(this IGridifySelecting selecting, IGridifyMapper<T>? mapper = null)
+   {
+      return selecting.IsValidSelect(out _, mapper);
+   }
+
+   /// <summary>
+   /// Validates a Select string against the mapper and reports per-path errors via
+   /// <paramref name="validationErrors"/>.
+   /// </summary>
+   /// <remarks>See remarks on the single-arg overload for why this is named <c>IsValidSelect</c>.</remarks>
+   public static bool IsValidSelect<T>(this IGridifySelecting selecting, out List<string> validationErrors, IGridifyMapper<T>? mapper = null)
+   {
+      validationErrors = new List<string>();
+      if (string.IsNullOrWhiteSpace(selecting.Select)) return true;
+
+      IReadOnlyList<string> paths;
+      try
+      {
+         paths = SelectTokenizer.Parse(selecting.Select);
+      }
+      catch (GridifySelectException ex)
+      {
+         validationErrors.Add(ex.Message);
+         return false;
+      }
+
+      mapper ??= new GridifyMapper<T>(autoGenerateMappings: true, maxNestingDepth: 1);
+
+      foreach (var path in paths)
+      {
+         try
+         {
+            _ = Builder.SelectExpressionBuilder<T>.Build(path, mapper);
+         }
+         catch (GridifySelectException ex)
+         {
+            validationErrors.Add(ex.Message);
+         }
+      }
+
+      return validationErrors.Count == 0;
    }
 
    public static bool IsValid<T>(this IGridifyFiltering filtering, IGridifyMapper<T>? mapper = null)

--- a/src/Gridify/GridifyExtensions.cs
+++ b/src/Gridify/GridifyExtensions.cs
@@ -348,16 +348,13 @@ public static partial class GridifyExtensions
 
       mapper ??= new GridifyMapper<T>(autoGenerateMappings: true, maxNestingDepth: 1);
 
-      foreach (var path in paths)
+      try
       {
-         try
-         {
-            _ = Builder.SelectExpressionBuilder<T>.Build(path, mapper);
-         }
-         catch (GridifySelectException ex)
-         {
-            validationErrors.Add(ex.Message);
-         }
+         Builder.SelectExpressionBuilder<T>.ValidatePaths(paths, mapper, validationErrors);
+      }
+      catch (Exception ex)
+      {
+         validationErrors.Add($"Validation error: {ex.Message}");
       }
 
       return validationErrors.Count == 0;

--- a/src/Gridify/GridifyExtensions.cs
+++ b/src/Gridify/GridifyExtensions.cs
@@ -467,6 +467,34 @@ public static partial class GridifyExtensions
       return new Paging<T>(count, queryable.ToList());
    }
 
+   /// <summary>
+   /// Applies filtering, ordering, paging, and field projection (Select) to the query.
+   /// Returns a <see cref="QueryablePaging{T}"/> of <see cref="object"/> where each item
+   /// is a runtime-emitted type with only the requested Select fields. If the query has
+   /// no Select string, items remain boxed instances of <typeparamref name="T"/>.
+   /// </summary>
+   public static QueryablePaging<object> GridifyQueryableSelect<T>(this IQueryable<T> query, IGridifyQuery? gridifyQuery, IGridifyMapper<T>? mapper = null)
+   {
+      query = query.ApplyFiltering(gridifyQuery, mapper);
+      var count = query.Count();
+      query = query.ApplyOrdering(gridifyQuery, mapper);
+      query = query.ApplyPaging(gridifyQuery);
+
+      var selecting = gridifyQuery as IGridifySelecting;
+      var projected = query.ApplySelect(selecting, mapper);
+      return new QueryablePaging<object>(count, projected);
+   }
+
+   /// <summary>
+   /// Applies filtering, ordering, paging, and field projection (Select), then materializes
+   /// the result. Returns a <see cref="Paging{T}"/> of <see cref="object"/>.
+   /// </summary>
+   public static Paging<object> GridifySelect<T>(this IQueryable<T> query, IGridifyQuery? gridifyQuery, IGridifyMapper<T>? mapper = null)
+   {
+      var (count, projected) = query.GridifyQueryableSelect(gridifyQuery, mapper);
+      return new Paging<object>(count, projected.ToList());
+   }
+
    #endregion
 
    /// <summary>

--- a/src/Gridify/GridifyQuery.cs
+++ b/src/Gridify/GridifyQuery.cs
@@ -1,6 +1,6 @@
 namespace Gridify;
 
-public class GridifyQuery : IGridifyQuery
+public class GridifyQuery : IGridifyQuery, IGridifySelecting
 {
    public GridifyQuery()
    {
@@ -17,4 +17,5 @@ public class GridifyQuery : IGridifyQuery
    public int PageSize { get; set; }
    public string? OrderBy { get; set; }
    public string? Filter { get; set; }
+   public string? Select { get; set; }
 }

--- a/src/Gridify/IGridifySelecting.cs
+++ b/src/Gridify/IGridifySelecting.cs
@@ -1,0 +1,6 @@
+namespace Gridify;
+
+public interface IGridifySelecting
+{
+   string? Select { get; set; }
+}

--- a/src/Gridify/IQueryBuilder.cs
+++ b/src/Gridify/IQueryBuilder.cs
@@ -363,4 +363,22 @@ public interface IQueryBuilder<T>
    /// </example>
    /// <returns><![CDATA[ Func<IQueryable<T>,Paging<T>> ]]></returns>
    Func<IEnumerable<T>, Paging<T>> BuildWithPagingCompiled();
+
+   /// <summary>
+   /// Configures a select (field projection) string. Has no effect on the typed Build* family;
+   /// only applies when calling BuildSelect / BuildSelectWithPaging.
+   /// </summary>
+   IQueryBuilder<T> AddSelect(string select);
+
+   /// <summary>Builds the projection delegate.</summary>
+   Func<IQueryable<T>, IQueryable<object>> BuildSelect();
+
+   /// <summary>Applies filtering, ordering, paging, and projection to the given queryable.</summary>
+   IQueryable<object> BuildSelect(IQueryable<T> context);
+
+   /// <summary>Builds a delegate that returns Paging&lt;object&gt; with the projection applied.</summary>
+   Func<IQueryable<T>, Paging<object>> BuildSelectWithPaging();
+
+   /// <summary>Applies filtering, ordering, paging, and projection, returning Paging&lt;object&gt;.</summary>
+   Paging<object> BuildSelectWithPaging(IQueryable<T> context);
 }

--- a/src/Gridify/IQueryBuilder.cs
+++ b/src/Gridify/IQueryBuilder.cs
@@ -198,9 +198,15 @@ public interface IQueryBuilder<T>
    IQueryBuilder<T> RemoveMap(IGMap<T> map);
 
    /// <summary>
-   /// Validate conditions, orderings, mappings
-   /// make sure to use ir after your configurations and before the Build methods
+   /// Validate filter conditions and orderings against the configured mappings.
+   /// Use this after configuring the builder and before the Build methods.
    /// </summary>
+   /// <remarks>
+   /// This method does <b>not</b> validate the select string supplied via
+   /// <see cref="AddSelect"/>. To validate the select string, call
+   /// <c>IsValidSelect()</c> on an <see cref="IGridifySelecting"/> instance
+   /// (for example <c>new GridifyQuery { Select = "..." }.IsValidSelect(mapper)</c>).
+   /// </remarks>
    /// <returns>boolean true/false</returns>
    bool IsValid();
 
@@ -368,6 +374,11 @@ public interface IQueryBuilder<T>
    /// Configures a select (field projection) string. Has no effect on the typed Build* family;
    /// only applies when calling BuildSelect / BuildSelectWithPaging.
    /// </summary>
+   /// <remarks>
+   /// <see cref="IsValid"/> does not validate the select string. To validate it before building,
+   /// call <c>new GridifyQuery { Select = select }.IsValidSelect(mapper)</c>
+   /// — see <see cref="GridifyExtensions.IsValidSelect{T}(IGridifySelecting, IGridifyMapper{T})"/>.
+   /// </remarks>
    IQueryBuilder<T> AddSelect(string select);
 
    /// <summary>Builds the projection delegate.</summary>

--- a/src/Gridify/QueryBuilder.cs
+++ b/src/Gridify/QueryBuilder.cs
@@ -13,6 +13,7 @@ public class QueryBuilder<T> : IQueryBuilder<T>
    private IGridifyMapper<T>? _mapper;
    private string _orderBy = string.Empty;
    private (int page, int pageSize)? _paging;
+   private string? _select;
 
    /// <inheritdoc />
    public IQueryBuilder<T> UseCustomMapper(IGridifyMapper<T> mapper)
@@ -62,6 +63,9 @@ public class QueryBuilder<T> : IQueryBuilder<T>
 
       if (gridifyQuery.PageSize == 0) gridifyQuery.PageSize = GridifyGlobalConfiguration.DefaultPageSize;
       ConfigurePaging(gridifyQuery.Page, gridifyQuery.PageSize);
+
+      if (gridifyQuery is IGridifySelecting selecting && !string.IsNullOrWhiteSpace(selecting.Select))
+         AddSelect(selecting.Select!);
 
       return this;
    }
@@ -420,4 +424,42 @@ public class QueryBuilder<T> : IQueryBuilder<T>
 
       return syntaxTree.CreateQuery(_mapper);
    }
+
+   /// <inheritdoc />
+   public IQueryBuilder<T> AddSelect(string select)
+   {
+      _select = select;
+      return this;
+   }
+
+   /// <inheritdoc />
+   public IQueryable<object> BuildSelect(IQueryable<T> context)
+   {
+      var query = Build(context);
+      return query.ApplySelect(_select, _mapper);
+   }
+
+   /// <inheritdoc />
+   public Func<IQueryable<T>, IQueryable<object>> BuildSelect() => BuildSelect;
+
+   /// <inheritdoc />
+   public Paging<object> BuildSelectWithPaging(IQueryable<T> context)
+   {
+      var query = context;
+      if (_conditionList.Count > 0)
+         query = query.Where(BuildFilteringExpression());
+      if (!string.IsNullOrEmpty(_orderBy))
+         query = query.ApplyOrdering(_orderBy, _mapper);
+
+      var count = query.Count();
+
+      if (_paging.HasValue)
+         query = query.Skip(_paging.Value.page * _paging.Value.pageSize).Take(_paging.Value.pageSize);
+
+      var projected = query.ApplySelect(_select, _mapper).ToList();
+      return new Paging<object>(count, projected);
+   }
+
+   /// <inheritdoc />
+   public Func<IQueryable<T>, Paging<object>> BuildSelectWithPaging() => BuildSelectWithPaging;
 }

--- a/src/Gridify/Syntax/SelectTokenizer.cs
+++ b/src/Gridify/Syntax/SelectTokenizer.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace Gridify.Syntax;
+
+internal static class SelectTokenizer
+{
+   private static readonly Regex PathRegex = new(@"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$", RegexOptions.Compiled);
+
+   public static IReadOnlyList<string> Parse(string? input)
+   {
+      if (string.IsNullOrWhiteSpace(input))
+         return Array.Empty<string>();
+
+      var rawTokens = input!.Split(',');
+      var seen = new HashSet<string>(StringComparer.Ordinal);
+      var result = new List<string>(rawTokens.Length);
+
+      foreach (var raw in rawTokens)
+      {
+         var token = raw.Trim();
+         if (token.Length == 0)
+            throw new GridifySelectException($"Invalid select syntax: empty token in '{input}'");
+
+         if (!PathRegex.IsMatch(token))
+            throw new GridifySelectException($"Invalid select syntax near '{token}'");
+
+         if (seen.Add(token))
+            result.Add(token);
+      }
+
+      return result;
+   }
+}

--- a/test/EntityFrameworkSqlProviderIntegrationTests/SelectSqlTests.cs
+++ b/test/EntityFrameworkSqlProviderIntegrationTests/SelectSqlTests.cs
@@ -51,4 +51,20 @@ public class SelectSqlTests
       Assert.DoesNotContain("[CreateDate]", sql);
       Assert.DoesNotContain("[FkGuid]", sql);
    }
+
+   [Fact]
+   public void ApplySelect_CollectionProjection_IsTranslatedToSql()
+   {
+      // Project a navigation collection (User.Groups[].Name). This must translate to SQL
+      // (a JOIN or correlated subquery). If Enumerable.Select is used in a way EF Core
+      // cannot translate, the query falls back to client-side evaluation or throws —
+      // ToQueryString() in particular throws InvalidOperationException on untranslatable
+      // expressions, which is what this test guards against.
+      var sql = _dbContext.Users.ApplySelect("name,groups.name").ToQueryString();
+
+      // The User.Name column must appear; columns not requested must not.
+      Assert.Contains("[Name]", sql);
+      Assert.DoesNotContain("[CreateDate]", sql);
+      Assert.DoesNotContain("[FkGuid]", sql);
+   }
 }

--- a/test/EntityFrameworkSqlProviderIntegrationTests/SelectSqlTests.cs
+++ b/test/EntityFrameworkSqlProviderIntegrationTests/SelectSqlTests.cs
@@ -1,0 +1,54 @@
+#nullable enable
+using System.Linq;
+using Gridify;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace EntityFrameworkIntegrationTests.cs;
+
+public class SelectSqlTests
+{
+   private readonly MyDbContext _dbContext = new();
+
+   [Fact]
+   public void ApplySelect_GeneratesColumnPrunedSql()
+   {
+      var sql = _dbContext.Users.ApplySelect("name").ToQueryString();
+
+      // SELECT must mention the projected column.
+      Assert.Contains("[Name]", sql);
+      // It must not mention columns the user did not request.
+      Assert.DoesNotContain("[CreateDate]", sql);
+      Assert.DoesNotContain("[FkGuid]", sql);
+   }
+
+   [Fact]
+   public void ApplySelect_NullOrWhitespace_GeneratesNormalSelect()
+   {
+      var sql = _dbContext.Users.ApplySelect((string?)null).ToQueryString();
+      Assert.StartsWith("SELECT", sql);
+   }
+
+   [Fact]
+   public void ApplySelect_TwoFields_BothColumnsAppearOthersDoNot()
+   {
+      var sql = _dbContext.Users.ApplySelect("name,id").ToQueryString();
+
+      Assert.Contains("[Name]", sql);
+      Assert.Contains("[Id]", sql);
+      Assert.DoesNotContain("[CreateDate]", sql);
+      Assert.DoesNotContain("[FkGuid]", sql);
+   }
+
+   [Fact]
+   public void ApplyFiltering_ThenApplySelect_FilterAndProjectionBothAppear()
+   {
+      var gq = new GridifyQuery { Filter = "name=John", Select = "name,id" };
+      var sql = _dbContext.Users.ApplyFiltering(gq).ApplySelect((IGridifySelecting)gq).ToQueryString();
+
+      Assert.Contains("WHERE", sql);
+      Assert.Contains("[Name]", sql);
+      Assert.DoesNotContain("[CreateDate]", sql);
+      Assert.DoesNotContain("[FkGuid]", sql);
+   }
+}

--- a/test/EntityFrameworkSqlProviderIntegrationTests/SelectSqlTests.cs
+++ b/test/EntityFrameworkSqlProviderIntegrationTests/SelectSqlTests.cs
@@ -67,4 +67,22 @@ public class SelectSqlTests
       Assert.DoesNotContain("[CreateDate]", sql);
       Assert.DoesNotContain("[FkGuid]", sql);
    }
+
+   [Fact]
+   public void ApplySelect_SingleSegmentAliasToCollectionProjection_IsTranslatedToSql()
+   {
+      // A mapper alias (groupNames) resolves to a collection projection
+      // (x.Groups.Select(g => g.Name)). The select string has only one segment but
+      // the resolved body is a Select(...) call — EF Core must still translate it.
+      var mapper = new GridifyMapper<User>(autoGenerateMappings: true)
+         .AddMap("groupNames", x => x.Groups.Select(g => g.Name));
+
+      var sql = _dbContext.Users.ApplySelect("groupNames", mapper).ToQueryString();
+
+      // The Group.Name column must appear (LEFT JOIN against Groups), and unrelated
+      // User columns must not.
+      Assert.Contains("[Name]", sql);
+      Assert.DoesNotContain("[CreateDate]", sql);
+      Assert.DoesNotContain("[FkGuid]", sql);
+   }
 }

--- a/test/Gridify.Tests/QueryBuilderSelectTests.cs
+++ b/test/Gridify.Tests/QueryBuilderSelectTests.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using System.Linq;
+using Gridify;
+using Xunit;
+
+namespace Gridify.Tests;
+
+public class QueryBuilderSelectTests
+{
+   private static List<TestClass> SampleData() =>
+   [
+      new(1, "Alice", null),
+      new(2, "Bob", null),
+      new(3, "Carol", null)
+   ];
+
+   [Fact]
+   public void AddSelect_BuildSelect_ReturnsProjectedQueryable()
+   {
+      var qb = new QueryBuilder<TestClass>().AddSelect("name");
+      var data = SampleData().AsQueryable();
+      var result = qb.BuildSelect(data).ToList();
+
+      Assert.Equal(3, result.Count);
+      Assert.NotNull(result[0].GetType().GetProperty("name"));
+   }
+
+   [Fact]
+   public void AddSelect_DoesNotAffectTypedBuild()
+   {
+      var qb = new QueryBuilder<TestClass>().AddSelect("name");
+      var data = SampleData().AsQueryable();
+      var typedResult = qb.Build(data).ToList();
+
+      Assert.All(typedResult, x => Assert.IsType<TestClass>(x));
+   }
+
+   [Fact]
+   public void BuildSelectWithPaging_PaginatesAndProjects()
+   {
+      var qb = new QueryBuilder<TestClass>()
+         .AddCondition("id>0")
+         .ConfigurePaging(0, 2)
+         .AddSelect("name");
+      var data = SampleData().AsQueryable();
+      Paging<object> result = qb.BuildSelectWithPaging(data);
+
+      Assert.Equal(3, result.Count);
+      Assert.Equal(2, result.Data.Count());
+   }
+
+   [Fact]
+   public void BuildSelect_FuncOverload_Works()
+   {
+      var qb = new QueryBuilder<TestClass>().AddSelect("name");
+      var data = SampleData().AsQueryable();
+      var fn = qb.BuildSelect();
+      var result = fn(data).ToList();
+      Assert.Equal(3, result.Count);
+   }
+
+   [Fact]
+   public void AddQuery_WithSelect_ForwardsToBuilder()
+   {
+      // QueryBuilder treats Page as 0-indexed (Skip(page * pageSize)). Use Page = 0 to fetch the first page.
+      var gq = new GridifyQuery { Select = "name", Page = 0, PageSize = 10 };
+      var qb = new QueryBuilder<TestClass>().AddQuery(gq);
+      var data = SampleData().AsQueryable();
+      var result = qb.BuildSelect(data).ToList();
+
+      Assert.Equal(3, result.Count);
+      Assert.NotNull(result[0].GetType().GetProperty("name"));
+   }
+}

--- a/test/Gridify.Tests/SelectTests.cs
+++ b/test/Gridify.Tests/SelectTests.cs
@@ -349,3 +349,51 @@ public class GridifyQuerySelectTests
       Assert.Null(q.Select);
    }
 }
+
+public class ApplySelectTests
+{
+   private static List<TestClass> SampleData() =>
+   [
+      new(1, "Alice", null),
+      new(2, "Bob", null),
+      new(3, "Carol", null)
+   ];
+
+   [Fact]
+   public void ApplySelect_FlatProjection_ReturnsRequestedFields()
+   {
+      var data = SampleData().AsQueryable();
+      var result = data.ApplySelect("name,id").ToList();
+
+      Assert.Equal(3, result.Count);
+      var first = result[0];
+      Assert.NotNull(first.GetType().GetProperty("name"));
+      Assert.NotNull(first.GetType().GetProperty("id"));
+      Assert.Equal("Alice", first.GetType().GetProperty("name")!.GetValue(first));
+   }
+
+   [Fact]
+   public void ApplySelect_NullOrWhitespace_ReturnsCastedQuery()
+   {
+      var data = SampleData().AsQueryable();
+      Assert.Equal(3, data.ApplySelect((string?)null).Count());
+      Assert.Equal(3, data.ApplySelect("").Count());
+      Assert.Equal(3, data.ApplySelect("   ").Count());
+   }
+
+   [Fact]
+   public void ApplySelect_IGridifySelectingOverload_Works()
+   {
+      var data = SampleData().AsQueryable();
+      IGridifySelecting selecting = new GridifyQuery { Select = "name" };
+      var result = data.ApplySelect(selecting).ToList();
+      Assert.Equal(3, result.Count);
+   }
+
+   [Fact]
+   public void ApplySelect_NullSelecting_ReturnsCastedQuery()
+   {
+      var data = SampleData().AsQueryable();
+      Assert.Equal(3, data.ApplySelect((IGridifySelecting?)null).Count());
+   }
+}

--- a/test/Gridify.Tests/SelectTests.cs
+++ b/test/Gridify.Tests/SelectTests.cs
@@ -332,3 +332,20 @@ public class SelectExpressionBuilderTests
       Assert.Contains("collection", ex.Message, System.StringComparison.OrdinalIgnoreCase);
    }
 }
+
+public class GridifyQuerySelectTests
+{
+   [Fact]
+   public void GridifyQuery_ImplementsIGridifySelecting()
+   {
+      IGridifySelecting q = new GridifyQuery { Select = "name,age" };
+      Assert.Equal("name,age", q.Select);
+   }
+
+   [Fact]
+   public void GridifyQuery_DefaultSelect_IsNull()
+   {
+      var q = new GridifyQuery();
+      Assert.Null(q.Select);
+   }
+}

--- a/test/Gridify.Tests/SelectTests.cs
+++ b/test/Gridify.Tests/SelectTests.cs
@@ -396,6 +396,22 @@ public class ApplySelectTests
       var data = SampleData().AsQueryable();
       Assert.Equal(3, data.ApplySelect((IGridifySelecting?)null).Count());
    }
+
+   [Fact]
+   public void ApplySelect_PartialMapperWithIgnoreNotMapped_DropsUnmappedFields()
+   {
+      var mapper = new GridifyMapper<TestClass>(c => c.IgnoreNotMappedFields = true)
+         .AddMap("name", x => x.Name!);
+      var data = SampleData().AsQueryable();
+
+      var result = data.ApplySelect("name,id,doesNotExist", mapper).ToList();
+
+      Assert.Equal(3, result.Count);
+      var first = result[0];
+      Assert.NotNull(first.GetType().GetProperty("name"));
+      Assert.Null(first.GetType().GetProperty("id"));
+      Assert.Null(first.GetType().GetProperty("doesNotExist"));
+   }
 }
 
 public class GridifySelectPipelineTests

--- a/test/Gridify.Tests/SelectTests.cs
+++ b/test/Gridify.Tests/SelectTests.cs
@@ -204,3 +204,131 @@ public class SelectTypeFactoryTests
       Assert.Single(results.Distinct());
    }
 }
+
+public class SelectExpressionBuilderTests
+{
+   [Fact]
+   public void Build_FlatProjection_ReturnsLambdaThatProjectsCorrectly()
+   {
+      var mapper = new GridifyMapper<TestClass>(autoGenerateMappings: true);
+      var lambda = Gridify.Builder.SelectExpressionBuilder<TestClass>.Build("name,id", mapper);
+
+      var compiled = lambda.Compile();
+      var input = new TestClass(7, "Alice", null);
+      var projected = compiled(input);
+
+      var nameProp = projected.GetType().GetProperty("name");
+      var idProp = projected.GetType().GetProperty("id");
+      Assert.NotNull(nameProp);
+      Assert.NotNull(idProp);
+      Assert.Equal("Alice", nameProp!.GetValue(projected));
+      Assert.Equal(7, idProp!.GetValue(projected));
+   }
+
+   [Fact]
+   public void Build_NestedPath_ProducesNestedProjection()
+   {
+      var mapper = new GridifyMapper<TestClass>(autoGenerateMappings: true, maxNestingDepth: 2);
+      var lambda = Gridify.Builder.SelectExpressionBuilder<TestClass>.Build("childClass.name", mapper);
+
+      var compiled = lambda.Compile();
+      var input = new TestClass(1, "Outer", new TestClass(2, "Inner", null));
+      var projected = compiled(input);
+
+      var childProp = projected.GetType().GetProperty("childClass");
+      Assert.NotNull(childProp);
+
+      var inner = childProp!.GetValue(projected);
+      Assert.NotNull(inner);
+      var innerNameProp = inner!.GetType().GetProperty("name");
+      Assert.Equal("Inner", innerNameProp!.GetValue(inner));
+   }
+
+   [Fact]
+   public void Build_CollectionPath_ProducesEnumerableProjection()
+   {
+      var mapper = new GridifyMapper<TestClass>(autoGenerateMappings: true, maxNestingDepth: 2);
+      var lambda = Gridify.Builder.SelectExpressionBuilder<TestClass>.Build("children.name", mapper);
+
+      var compiled = lambda.Compile();
+      var input = new TestClass(1, "Parent", null);
+      input.Children.Add(new TestClass(2, "ChildA", null));
+      input.Children.Add(new TestClass(3, "ChildB", null));
+
+      var projected = compiled(input);
+      var childrenProp = projected.GetType().GetProperty("children");
+      Assert.NotNull(childrenProp);
+
+      var children = childrenProp!.GetValue(projected) as System.Collections.IEnumerable;
+      Assert.NotNull(children);
+
+      var names = new List<string?>();
+      foreach (var c in children!)
+      {
+         var nameProp = c.GetType().GetProperty("name");
+         names.Add((string?)nameProp!.GetValue(c));
+      }
+      Assert.Equal(new[] { "ChildA", "ChildB" }, names);
+   }
+
+   [Fact]
+   public void Build_UnmappedField_ThrowsByDefault()
+   {
+      var mapper = new GridifyMapper<TestClass>().AddMap("name", x => x.Name!);
+      Assert.Throws<GridifySelectException>(() =>
+         Gridify.Builder.SelectExpressionBuilder<TestClass>.Build("name,missingField", mapper));
+   }
+
+   [Fact]
+   public void Build_UnmappedField_WhenIgnoreNotMappedFields_DropsSilently()
+   {
+      var mapper = new GridifyMapper<TestClass>(c => c.IgnoreNotMappedFields = true)
+         .AddMap("name", x => x.Name!);
+
+      var lambda = Gridify.Builder.SelectExpressionBuilder<TestClass>.Build("name,missingField", mapper);
+      var compiled = lambda.Compile();
+      var projected = compiled(new TestClass(1, "Bob", null));
+
+      Assert.NotNull(projected.GetType().GetProperty("name"));
+      Assert.Null(projected.GetType().GetProperty("missingField"));
+   }
+
+   [Fact]
+   public void Build_TwoLevelCollection_Throws()
+   {
+      var mapper = new GridifyMapper<TestClass>(autoGenerateMappings: true, maxNestingDepth: 3);
+      Assert.Throws<GridifySelectException>(() =>
+         Gridify.Builder.SelectExpressionBuilder<TestClass>.Build("children.children.name", mapper));
+   }
+
+   [Fact]
+   public void Build_EmptySelect_Throws()
+   {
+      var mapper = new GridifyMapper<TestClass>(autoGenerateMappings: true);
+      Assert.Throws<GridifySelectException>(() =>
+         Gridify.Builder.SelectExpressionBuilder<TestClass>.Build("", mapper));
+   }
+
+   [Fact]
+   public void Build_MixedCaseFirstSegment_GroupsByMapperCaseSensitivity()
+   {
+      // Default mapper is case-insensitive. "Name" and "name" should be one property,
+      // not two, otherwise the emitted type has duplicate columns.
+      var mapper = new GridifyMapper<TestClass>(autoGenerateMappings: true);
+      var lambda = Gridify.Builder.SelectExpressionBuilder<TestClass>.Build("Name,name", mapper);
+      var compiled = lambda.Compile();
+      var projected = compiled(new TestClass(1, "Alice", null));
+
+      var props = projected.GetType().GetProperties();
+      Assert.Single(props);
+   }
+
+   [Fact]
+   public void Build_TwoLevelCollection_ErrorMentionsMultipleLevels()
+   {
+      var mapper = new GridifyMapper<TestClass>(autoGenerateMappings: true, maxNestingDepth: 3);
+      var ex = Assert.Throws<GridifySelectException>(() =>
+         Gridify.Builder.SelectExpressionBuilder<TestClass>.Build("children.children.name", mapper));
+      Assert.Contains("collection", ex.Message, System.StringComparison.OrdinalIgnoreCase);
+   }
+}

--- a/test/Gridify.Tests/SelectTests.cs
+++ b/test/Gridify.Tests/SelectTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Gridify;
+using Gridify.Syntax;
+using Xunit;
+
+namespace Gridify.Tests;
+
+public class SelectTokenizerTests
+{
+   [Fact]
+   public void Parse_SingleField_ReturnsOnePath()
+   {
+      var result = SelectTokenizer.Parse("name");
+      Assert.Equal(new[] { "name" }, result);
+   }
+
+   [Fact]
+   public void Parse_MultipleFields_ReturnsList()
+   {
+      var result = SelectTokenizer.Parse("name,age,tag");
+      Assert.Equal(new[] { "name", "age", "tag" }, result);
+   }
+
+   [Fact]
+   public void Parse_TrimsWhitespaceAroundEachToken()
+   {
+      var result = SelectTokenizer.Parse(" name , age ,  tag ");
+      Assert.Equal(new[] { "name", "age", "tag" }, result);
+   }
+
+   [Fact]
+   public void Parse_DottedPath_PreservedIntact()
+   {
+      var result = SelectTokenizer.Parse("address.city,orders.amount");
+      Assert.Equal(new[] { "address.city", "orders.amount" }, result);
+   }
+
+   [Fact]
+   public void Parse_DuplicateTokens_AreDeduplicated()
+   {
+      var result = SelectTokenizer.Parse("name,age,name,age");
+      Assert.Equal(new[] { "name", "age" }, result);
+   }
+
+   [Fact]
+   public void Parse_NullOrWhitespace_ReturnsEmpty()
+   {
+      Assert.Empty(SelectTokenizer.Parse(null));
+      Assert.Empty(SelectTokenizer.Parse(""));
+      Assert.Empty(SelectTokenizer.Parse("   "));
+   }
+
+   [Theory]
+   [InlineData(",")]
+   [InlineData("name,,age")]
+   [InlineData(",name")]
+   [InlineData("name,")]
+   [InlineData(".")]
+   [InlineData(".name")]
+   [InlineData("name.")]
+   [InlineData("name..age")]
+   [InlineData("1name")]
+   [InlineData("name space")]
+   [InlineData("name-bad")]
+   public void Parse_InvalidToken_Throws(string input)
+   {
+      Assert.Throws<GridifySelectException>(() => SelectTokenizer.Parse(input));
+   }
+}

--- a/test/Gridify.Tests/SelectTests.cs
+++ b/test/Gridify.Tests/SelectTests.cs
@@ -451,3 +451,47 @@ public class GridifySelectPipelineTests
       Assert.Equal(5, qp.Query.Count());
    }
 }
+
+public class IsValidSelectTests
+{
+   [Fact]
+   public void IsValidSelect_ValidSelect_ReturnsTrue()
+   {
+      var s = new GridifyQuery { Select = "name,id" };
+      Assert.True(((IGridifySelecting)s).IsValidSelect<TestClass>());
+   }
+
+   [Fact]
+   public void IsValidSelect_NullOrEmpty_ReturnsTrue()
+   {
+      Assert.True(((IGridifySelecting)new GridifyQuery { Select = null }).IsValidSelect<TestClass>());
+      Assert.True(((IGridifySelecting)new GridifyQuery { Select = "" }).IsValidSelect<TestClass>());
+   }
+
+   [Fact]
+   public void IsValidSelect_BadSyntax_ReturnsFalseWithError()
+   {
+      IGridifySelecting s = new GridifyQuery { Select = "name,," };
+      var ok = s.IsValidSelect<TestClass>(out var errors);
+      Assert.False(ok);
+      Assert.NotEmpty(errors);
+   }
+
+   [Fact]
+   public void IsValidSelect_UnmappedField_ReturnsFalseWithError()
+   {
+      IGridifySelecting s = new GridifyQuery { Select = "doesNotExist" };
+      var mapper = new GridifyMapper<TestClass>().AddMap("name", x => x.Name!);
+      var ok = s.IsValidSelect(out var errors, mapper);
+      Assert.False(ok);
+      Assert.Contains(errors, e => e.Contains("doesNotExist"));
+   }
+
+   [Fact]
+   public void GridifyQuery_IsValid_Composite_AlsoChecksSelect()
+   {
+      var gq = new GridifyQuery { Filter = "id=1", OrderBy = "name", Select = "doesNotExist" };
+      var mapper = new GridifyMapper<TestClass>(autoGenerateMappings: true);
+      Assert.False(gq.IsValid(mapper));
+   }
+}

--- a/test/Gridify.Tests/SelectTests.cs
+++ b/test/Gridify.Tests/SelectTests.cs
@@ -275,8 +275,11 @@ public class SelectExpressionBuilderTests
    public void Build_UnmappedField_ThrowsByDefault()
    {
       var mapper = new GridifyMapper<TestClass>().AddMap("name", x => x.Name!);
-      Assert.Throws<GridifySelectException>(() =>
+      // Asserting on the base GridifySelectException type — the concrete throw
+      // is the GridifySelectFieldNotMappedException subtype.
+      var ex = Assert.ThrowsAny<GridifySelectException>(() =>
          Gridify.Builder.SelectExpressionBuilder<TestClass>.Build("name,missingField", mapper));
+      Assert.IsType<GridifySelectFieldNotMappedException>(ex);
    }
 
    [Fact]
@@ -330,6 +333,46 @@ public class SelectExpressionBuilderTests
       var ex = Assert.Throws<GridifySelectException>(() =>
          Gridify.Builder.SelectExpressionBuilder<TestClass>.Build("children.children.name", mapper));
       Assert.Contains("collection", ex.Message, System.StringComparison.OrdinalIgnoreCase);
+   }
+
+   [Fact]
+   public void Build_StructuralCollectionError_PropagatesUnderIgnoreNotMappedFields()
+   {
+      // Mapper maps the collection prefix "children" but NOT "children.name".
+      // ResolvePath's prefix walk lands on the IEnumerable<TestClass>, then
+      // WalkSegment("name") fires the multi-level-collection guard. Even with
+      // IgnoreNotMappedFields=true the structural error must propagate — the
+      // path isn't unmapped, it's structurally unprojectable.
+      var mapper = new GridifyMapper<TestClass>(c => c.IgnoreNotMappedFields = true);
+      mapper.AddMap("children", x => x.Children);
+
+      var ex = Assert.Throws<GridifySelectException>(() =>
+         Gridify.Builder.SelectExpressionBuilder<TestClass>.Build("children.name", mapper));
+      Assert.False(ex is GridifySelectFieldNotMappedException);
+      Assert.Contains("collection", ex.Message, System.StringComparison.OrdinalIgnoreCase);
+   }
+
+   [Fact]
+   public void Build_NotAPropertyError_PropagatesUnderIgnoreNotMappedFields()
+   {
+      // Mapper maps "name" (a string). User asks for "name.bogus" — prefix walk
+      // hits "name", then tries Expression.Property(string, "bogus") which fails.
+      // Structural error, must propagate even with IgnoreNotMappedFields=true.
+      var mapper = new GridifyMapper<TestClass>(c => c.IgnoreNotMappedFields = true)
+         .AddMap("name", x => x.Name!);
+
+      var ex = Assert.Throws<GridifySelectException>(() =>
+         Gridify.Builder.SelectExpressionBuilder<TestClass>.Build("name.bogus", mapper));
+      Assert.False(ex is GridifySelectFieldNotMappedException);
+   }
+
+   [Fact]
+   public void Build_UnmappedField_ThrowsTypedSubException()
+   {
+      var mapper = new GridifyMapper<TestClass>().AddMap("name", x => x.Name!);
+      var ex = Assert.Throws<GridifySelectFieldNotMappedException>(() =>
+         Gridify.Builder.SelectExpressionBuilder<TestClass>.Build("missingField", mapper));
+      Assert.Equal("missingField", ex.Field);
    }
 }
 
@@ -509,5 +552,51 @@ public class IsValidSelectTests
       var gq = new GridifyQuery { Filter = "id=1", OrderBy = "name", Select = "doesNotExist" };
       var mapper = new GridifyMapper<TestClass>(autoGenerateMappings: true);
       Assert.False(gq.IsValid(mapper));
+   }
+
+   [Fact]
+   public void IsValidSelect_UnmappedField_UnderIgnoreNotMappedFields_ReturnsTrue()
+   {
+      // When IgnoreNotMappedFields=true, unmapped paths are silently dropped at
+      // runtime. The validator must mirror that and report no error.
+      var mapper = new GridifyMapper<TestClass>(c => c.IgnoreNotMappedFields = true)
+         .AddMap("name", x => x.Name!);
+      IGridifySelecting s = new GridifyQuery { Select = "name,doesNotExist" };
+
+      var ok = s.IsValidSelect(out var errors, mapper);
+
+      Assert.True(ok);
+      Assert.Empty(errors);
+   }
+
+   [Fact]
+   public void IsValidSelect_UnmappedField_ErrorMentionsField()
+   {
+      // Regression: under the old per-path Build() validator the error message
+      // was "Select produced no fields." for every unmapped path; now it should
+      // surface the actual "Field 'X' is not mapped" diagnostic.
+      var mapper = new GridifyMapper<TestClass>().AddMap("name", x => x.Name!);
+      IGridifySelecting s = new GridifyQuery { Select = "doesNotExist" };
+
+      var ok = s.IsValidSelect(out var errors, mapper);
+
+      Assert.False(ok);
+      Assert.Contains(errors, e => e.Contains("doesNotExist") && e.Contains("not mapped"));
+      Assert.DoesNotContain(errors, e => e.Contains("Select produced no fields"));
+   }
+
+   [Fact]
+   public void IsValidSelect_StructuralError_UnderIgnoreNotMappedFields_ReturnsFalse()
+   {
+      // Structural errors are not unmapped-field errors and must surface in the
+      // validator regardless of IgnoreNotMappedFields.
+      var mapper = new GridifyMapper<TestClass>(c => c.IgnoreNotMappedFields = true);
+      mapper.AddMap("children", x => x.Children);
+      IGridifySelecting s = new GridifyQuery { Select = "children.name" };
+
+      var ok = s.IsValidSelect(out var errors, mapper);
+
+      Assert.False(ok);
+      Assert.NotEmpty(errors);
    }
 }

--- a/test/Gridify.Tests/SelectTests.cs
+++ b/test/Gridify.Tests/SelectTests.cs
@@ -69,3 +69,138 @@ public class SelectTokenizerTests
       Assert.Throws<GridifySelectException>(() => SelectTokenizer.Parse(input));
    }
 }
+
+public class SelectTypeFactoryTests
+{
+   [Fact]
+   public void Create_FlatShape_EmitsTypeWithRequestedProperties()
+   {
+      var shape = new Gridify.Builder.SelectShape { SourceType = typeof(TestClass) };
+      shape.Children.Add(new Gridify.Builder.SelectNode
+      {
+         Name = "name",
+         Accessor = (System.Linq.Expressions.Expression<System.Func<TestClass, string?>>)(t => t.Name),
+         ResultType = typeof(string)
+      });
+      shape.Children.Add(new Gridify.Builder.SelectNode
+      {
+         Name = "id",
+         Accessor = (System.Linq.Expressions.Expression<System.Func<TestClass, int>>)(t => t.Id),
+         ResultType = typeof(int)
+      });
+
+      var emitted = Gridify.Builder.SelectTypeFactory.GetOrCreate(shape);
+
+      Assert.NotNull(emitted);
+      Assert.NotNull(emitted.GetProperty("name"));
+      Assert.Equal(typeof(string), emitted.GetProperty("name")!.PropertyType);
+      Assert.NotNull(emitted.GetProperty("id"));
+      Assert.Equal(typeof(int), emitted.GetProperty("id")!.PropertyType);
+      Assert.NotNull(emitted.GetConstructor(System.Type.EmptyTypes));
+      Assert.NotNull(System.Reflection.CustomAttributeExtensions.GetCustomAttribute<System.Runtime.CompilerServices.CompilerGeneratedAttribute>(emitted));
+   }
+
+   [Fact]
+   public void Create_SameShapeTwice_ReturnsSameType()
+   {
+      Gridify.Builder.SelectShape MakeShape()
+      {
+         var s = new Gridify.Builder.SelectShape { SourceType = typeof(TestClass) };
+         s.Children.Add(new Gridify.Builder.SelectNode
+         {
+            Name = "name",
+            Accessor = (System.Linq.Expressions.Expression<System.Func<TestClass, string?>>)(t => t.Name),
+            ResultType = typeof(string)
+         });
+         return s;
+      }
+
+      var a = Gridify.Builder.SelectTypeFactory.GetOrCreate(MakeShape());
+      var b = Gridify.Builder.SelectTypeFactory.GetOrCreate(MakeShape());
+
+      Assert.Same(a, b);
+   }
+
+   [Fact]
+   public void Create_DifferentShapes_ReturnsDifferentTypes()
+   {
+      var s1 = new Gridify.Builder.SelectShape { SourceType = typeof(TestClass) };
+      s1.Children.Add(new Gridify.Builder.SelectNode
+      {
+         Name = "name",
+         Accessor = (System.Linq.Expressions.Expression<System.Func<TestClass, string?>>)(t => t.Name),
+         ResultType = typeof(string)
+      });
+
+      var s2 = new Gridify.Builder.SelectShape { SourceType = typeof(TestClass) };
+      s2.Children.Add(new Gridify.Builder.SelectNode
+      {
+         Name = "id",
+         Accessor = (System.Linq.Expressions.Expression<System.Func<TestClass, int>>)(t => t.Id),
+         ResultType = typeof(int)
+      });
+
+      var a = Gridify.Builder.SelectTypeFactory.GetOrCreate(s1);
+      var b = Gridify.Builder.SelectTypeFactory.GetOrCreate(s2);
+
+      Assert.NotSame(a, b);
+   }
+
+   [Fact]
+   public void Create_NestedShape_EmitsNestedType()
+   {
+      var inner = new Gridify.Builder.SelectShape { SourceType = typeof(TestClass) };
+      inner.Children.Add(new Gridify.Builder.SelectNode
+      {
+         Name = "name",
+         Accessor = (System.Linq.Expressions.Expression<System.Func<TestClass, string?>>)(t => t.Name),
+         ResultType = typeof(string)
+      });
+
+      var root = new Gridify.Builder.SelectShape { SourceType = typeof(TestClass) };
+      var innerEmitted = Gridify.Builder.SelectTypeFactory.GetOrCreate(inner);
+      root.Children.Add(new Gridify.Builder.SelectNode
+      {
+         Name = "childClass",
+         Accessor = (System.Linq.Expressions.Expression<System.Func<TestClass, TestClass?>>)(t => t.ChildClass),
+         ResultType = innerEmitted,
+         ChildShape = inner
+      });
+
+      var emitted = Gridify.Builder.SelectTypeFactory.GetOrCreate(root);
+      var childProp = emitted.GetProperty("childClass");
+
+      Assert.NotNull(childProp);
+      Assert.Equal(innerEmitted, childProp!.PropertyType);
+   }
+
+   [Fact]
+   public void Create_ParallelGetOrCreate_IsThreadSafe()
+   {
+      Gridify.Builder.SelectShape MakeShape()
+      {
+         var s = new Gridify.Builder.SelectShape { SourceType = typeof(TestClass) };
+         s.Children.Add(new Gridify.Builder.SelectNode
+         {
+            Name = "name",
+            Accessor = (System.Linq.Expressions.Expression<System.Func<TestClass, string?>>)(t => t.Name),
+            ResultType = typeof(string)
+         });
+         s.Children.Add(new Gridify.Builder.SelectNode
+         {
+            Name = "id",
+            Accessor = (System.Linq.Expressions.Expression<System.Func<TestClass, int>>)(t => t.Id),
+            ResultType = typeof(int)
+         });
+         return s;
+      }
+
+      var results = new System.Collections.Concurrent.ConcurrentBag<System.Type>();
+      System.Threading.Tasks.Parallel.For(0, 32, _ =>
+      {
+         results.Add(Gridify.Builder.SelectTypeFactory.GetOrCreate(MakeShape()));
+      });
+
+      Assert.Single(results.Distinct());
+   }
+}

--- a/test/Gridify.Tests/SelectTests.cs
+++ b/test/Gridify.Tests/SelectTests.cs
@@ -374,6 +374,45 @@ public class SelectExpressionBuilderTests
          Gridify.Builder.SelectExpressionBuilder<TestClass>.Build("missingField", mapper));
       Assert.Equal("missingField", ex.Field);
    }
+
+   [Fact]
+   public void Build_CaseSensitiveMapper_CamelCasePrefix_ResolvesPascalCaseSuffix()
+   {
+      var mapper = new GridifyMapper<TestClass>(c => c.CaseSensitive = true)
+         .AddMap("childClass", x => x.ChildClass!);
+
+      var lambda = Gridify.Builder.SelectExpressionBuilder<TestClass>.Build("childClass.name", mapper);
+      var projected = lambda.Compile()(new TestClass(1, "Outer", new TestClass(2, "Inner", null)));
+
+      var inner = projected.GetType().GetProperty("childClass")!.GetValue(projected);
+      Assert.Equal("Inner", inner!.GetType().GetProperty("Name")!.GetValue(inner));
+   }
+
+   [Fact]
+   public void Build_CaseInsensitiveMapper_DifferentCasings_ProduceSameEmittedType()
+   {
+      var mapper = new GridifyMapper<TestClass>(autoGenerateMappings: true);
+
+      var a = Gridify.Builder.SelectExpressionBuilder<TestClass>.Build("id,name", mapper);
+      var b = Gridify.Builder.SelectExpressionBuilder<TestClass>.Build("Id,Name", mapper);
+
+      Assert.Same(a.ReturnType, b.ReturnType);
+   }
+
+   [Fact]
+   public void Build_CaseInsensitiveMapper_EmittedPropertyNames_FollowMapperCanonicalCasing()
+   {
+      var mapper = new GridifyMapper<TestClass>()
+         .AddMap("id", x => x.Id)
+         .AddMap("name", x => x.Name!);
+
+      var lambda = Gridify.Builder.SelectExpressionBuilder<TestClass>.Build("Id,Name", mapper);
+      var projected = lambda.Compile()(new TestClass(7, "Alice", null));
+
+      Assert.NotNull(projected.GetType().GetProperty("id"));
+      Assert.NotNull(projected.GetType().GetProperty("name"));
+      Assert.Equal(2, projected.GetType().GetProperties().Length);
+   }
 }
 
 public class GridifyQuerySelectTests

--- a/test/Gridify.Tests/SelectTests.cs
+++ b/test/Gridify.Tests/SelectTests.cs
@@ -413,6 +413,85 @@ public class SelectExpressionBuilderTests
       Assert.NotNull(projected.GetType().GetProperty("name"));
       Assert.Equal(2, projected.GetType().GetProperties().Length);
    }
+
+   [Fact]
+   public void Build_SingleSegmentAlias_MappedToNestedValue_ProjectsLeafValue()
+   {
+      // An alias that resolves to a nested value must project the leaf,
+      // not the first root segment of the resolved body.
+      var mapper = new GridifyMapper<TestClass>()
+         .AddMap("childName", x => x.ChildClass!.Name!);
+
+      var lambda = Gridify.Builder.SelectExpressionBuilder<TestClass>.Build("childName", mapper);
+      var projected = lambda.Compile()(new TestClass(1, "Outer", new TestClass(2, "Inner", null)));
+
+      var prop = projected.GetType().GetProperty("childName");
+      Assert.NotNull(prop);
+      Assert.Equal(typeof(string), prop!.PropertyType);
+      Assert.Equal("Inner", prop.GetValue(projected));
+   }
+
+   [Fact]
+   public void Build_SingleSegmentAlias_MappedToCollectionProjection_ProjectsProjectedCollection()
+   {
+      // An alias that resolves to a collection projection must project the
+      // projected sequence, not the source collection it was projected from.
+      var mapper = new GridifyMapper<TestClass>()
+         .AddMap("childNames", x => x.Children.Select(c => c.Name!));
+
+      var lambda = Gridify.Builder.SelectExpressionBuilder<TestClass>.Build("childNames", mapper);
+      var source = new TestClass(1, "Outer", null)
+      {
+         Children =
+         {
+            new TestClass(2, "A", null),
+            new TestClass(3, "B", null)
+         }
+      };
+      var projected = lambda.Compile()(source);
+
+      var prop = projected.GetType().GetProperty("childNames");
+      Assert.NotNull(prop);
+      var value = prop!.GetValue(projected);
+      var names = Assert.IsAssignableFrom<IEnumerable<string>>(value);
+      Assert.Equal(new[] { "A", "B" }, names);
+   }
+
+   [Fact]
+   public void Build_DottedIntoAliasWithNonMemberChainBody_ThrowsClearError()
+   {
+      // Dotting into an alias whose body is not a plain member chain currently throws.
+      // Lock this in so any future widening of supported alias-body shapes is intentional.
+      var mapper = new GridifyMapper<TestClass>()
+         .AddMap("display", x => x.Name ?? x.Tag ?? string.Empty);
+
+      var ex = Assert.Throws<GridifySelectException>(() =>
+         Gridify.Builder.SelectExpressionBuilder<TestClass>.Build("display.Length", mapper));
+      Assert.False(ex is GridifySelectFieldNotMappedException);
+   }
+
+   [Fact]
+   public void Build_MixedSingleSegmentAliasAndNestedWalk_BothProjectCorrectly()
+   {
+      // Stresses grouping: childName is a single-segment alias resolving to x.ChildClass.Name
+      // while childClass.id is a real nested walk. They live in different groups
+      // (different first segments), so both should project their resolved leaves.
+      var mapper = new GridifyMapper<TestClass>()
+         .AddMap("childName", x => x.ChildClass!.Name!)
+         .AddMap("childClass", x => x.ChildClass!);
+
+      var lambda = Gridify.Builder.SelectExpressionBuilder<TestClass>.Build("childName,childClass.id", mapper);
+      var projected = lambda.Compile()(new TestClass(1, "Outer", new TestClass(42, "Inner", null)));
+
+      var childName = projected.GetType().GetProperty("childName")!.GetValue(projected);
+      Assert.Equal("Inner", childName);
+
+      var childClass = projected.GetType().GetProperty("childClass")!.GetValue(projected);
+      Assert.NotNull(childClass);
+      // Walked suffix segments canonicalize to CLR prop.Name (PascalCase), so the
+      // emitted nested property is "Id" even though the user wrote "childClass.id".
+      Assert.Equal(42, childClass!.GetType().GetProperty("Id")!.GetValue(childClass));
+   }
 }
 
 public class GridifyQuerySelectTests

--- a/test/Gridify.Tests/SelectTests.cs
+++ b/test/Gridify.Tests/SelectTests.cs
@@ -397,3 +397,57 @@ public class ApplySelectTests
       Assert.Equal(3, data.ApplySelect((IGridifySelecting?)null).Count());
    }
 }
+
+public class GridifySelectPipelineTests
+{
+   private static List<TestClass> SampleData() =>
+   [
+      new(1, "Alice", null),
+      new(2, "Bob", null),
+      new(3, "Carol", null),
+      new(4, "Dave", null),
+      new(5, "Eve", null)
+   ];
+
+   [Fact]
+   public void GridifySelect_AppliesFilterOrderingPagingAndProjection()
+   {
+      var data = SampleData().AsQueryable();
+      var gq = new GridifyQuery
+      {
+         Filter = "id>1",
+         OrderBy = "name",
+         Page = 1,
+         PageSize = 2,
+         Select = "name,id"
+      };
+      Paging<object> result = data.GridifySelect(gq);
+
+      Assert.Equal(4, result.Count); // filtered count (id > 1) = 4
+      Assert.Equal(2, result.Data.Count()); // page size
+      var first = result.Data.First();
+      Assert.NotNull(first.GetType().GetProperty("name"));
+   }
+
+   [Fact]
+   public void GridifySelect_NoSelect_ReturnsBoxedT()
+   {
+      var data = SampleData().AsQueryable();
+      var gq = new GridifyQuery { Page = 1, PageSize = 10 };
+      var result = data.GridifySelect(gq);
+
+      Assert.Equal(5, result.Count);
+      Assert.All(result.Data, item => Assert.IsType<TestClass>(item));
+   }
+
+   [Fact]
+   public void GridifyQueryableSelect_ReturnsQueryablePagingOfObject()
+   {
+      var data = SampleData().AsQueryable();
+      var gq = new GridifyQuery { Select = "name", Page = 1, PageSize = 10 };
+      QueryablePaging<object> qp = data.GridifyQueryableSelect(gq);
+
+      Assert.Equal(5, qp.Count);
+      Assert.Equal(5, qp.Query.Count());
+   }
+}


### PR DESCRIPTION
# Description

Adds first-class **field projection** to Gridify. Callers can supply a `Select` string (e.g., `select=name,address.city,orders.amount`) alongside `Filter`, `OrderBy`, `Page`, and `PageSize`, and Gridify projects the queryable to a sequence of dynamically-typed objects containing only the requested fields. Under EF Core this translates to column-pruned SQL.

This replaces the half-implemented `ApplySelect` stub in `GridifyExtensions.cs` and addresses the integration gaps that caused PR #62 to be closed (no breaking changes; full integration with `Gridify()`, `GridifyQueryable()`, `QueryBuilder`; verified EF compatibility).

## Highlights

- **No breaking API changes.** `IGridifyQuery` / `IGridifyFiltering` / `IGridifyOrdering` / `IGridifyPagination` are unchanged. The new `IGridifySelecting` interface is additive — `GridifyQuery` implements it, but direct implementors of `IGridifyQuery` are unaffected.
- **End-to-end pipeline integration.** Two `ApplySelect` overloads, the projecting `GridifySelect` / `GridifyQueryableSelect` pipeline methods, and `QueryBuilder.AddSelect` + `BuildSelect` / `BuildSelectWithPaging` family. `QueryBuilder.AddQuery` forwards `Select` automatically when the supplied query also implements `IGridifySelecting`.
- **EF Core compatibility verified.** `ToQueryString()` assertions confirm column-pruned `SELECT` output, including a collection-projection (`groups.name`) test that catches client-side-evaluation regressions.
- **Validation.** `IsValidSelect` mirrors the existing Filter / Order validators (with `out List<string> errors` overload); the composite `IGridifyQuery.IsValid` is extended to also cover `Select` when the query implements `IGridifySelecting`.
- **Zero new dependencies.** Hand-rolled IL emission via `System.Reflection.Emit.TypeBuilder`, cached per shape signature with double-checked locking.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes

## Limitations / non-goals

- **Aliasing / renaming** in v1 (`select=fullName:firstName,...`) — out of scope.
- **Computed fields, aggregations** (`count`, `sum`) — out of scope.
- **Multiple levels of collection nesting.** v1 supports one collection level (e.g., `orders.amount` works; `orders.items.price` does not). Deeper projections throw `GridifySelectException` with a clear message.
- **`Gridify.Elasticsearch`** is a follow-up (Elasticsearch projects via `_source` field filtering, which is a parallel design problem).
- **NativeAOT.** Issue #140 remains open; under NativeAOT `SelectTypeFactory` throws `GridifySelectException` referencing #140.

## Tests

- 691 / 691 across all 5 projects.
- Unit tests cover: tokenizer (valid / invalid / dedup / whitespace), IL emission cache + thread safety, expression-builder shapes (flat / nested / collection / mixed-case / case-sensitivity), `ApplySelect` end-to-end on `IQueryable<T>`, `IsValidSelect` (including the `IgnoreNotMappedFields` path and structural-error propagation), and the `QueryBuilder.AddSelect` / `BuildSelect*` API.
- EF integration tests assert column-pruned SQL via `ToQueryString()` for flat, two-field, filter-then-select, and collection-projection cases.

## Notes for reviewers

The opening commits introduce the building blocks (tokenizer, factory, expression builder); the later commits wire them into the public API and tests. The two `fix(select):` commits at the head address findings from a structured pre-PR review — narrowing `IgnoreNotMappedFields` to a typed `GridifySelectFieldNotMappedException` subtype so structural errors (multi-level collection, missing-property-on-resolved-type) propagate even with the flag on, refactoring `IsValidSelect` to use a validator-only path resolver that doesn't pollute the `SelectTypeFactory` cache, and tightening the validator to `catch (Exception)` matching the existing `IsValid` validators' contract.