### PR TITLE
feat(mapper): add case-insensitive per-map override

### DIFF
--- a/docs/pages/guide/gridifyMapper.md
+++ b/docs/pages/guide/gridifyMapper.md
@@ -80,6 +80,7 @@ This method adds a mapping to the mapper.
 - the first parameter is the name of the field you want to use in the string query
 - the second parameter is a property selector expression
 - the third parameter is an optional [value convertor](#value-convertor) expression that you can use to convert user inputs to anything you want
+- the optional `caseInsensitive` parameter lets you override `CaseInsensitiveFiltering` for a specific map (`true` = force case-insensitive, `false` = force case-sensitive)
 
 ### Value Convertor
 
@@ -349,6 +350,14 @@ If true, string comparison operations are case insensitive by default.
 
 ``` csharp
 var mapper = new GridifyMapper<Person>(q => q.CaseInsensitiveFiltering = true);
+```
+
+You can also override this behavior per map:
+
+```csharp
+var mapper = new GridifyMapper<Person>(q => q.CaseInsensitiveFiltering = true)
+   .AddMap("userName", p => p.UserName, caseInsensitive: false)
+   .AddMap("email", p => p.Email, caseInsensitive: true);
 ```
 
 ### DefaultDateTimeKind

--- a/src/Gridify/Builder/BaseQueryBuilder.cs
+++ b/src/Gridify/Builder/BaseQueryBuilder.cs
@@ -148,7 +148,7 @@ public abstract class BaseQueryBuilder<TQuery, T>(IGridifyMapper<T> mapper)
             }
             else
             {
-               var exprQuery = BuildQuery(exprMapTarget.Body, exprMapTarget.Parameters[0], right, op, gMap.Convertor, false);
+               var exprQuery = BuildQuery(exprMapTarget.Body, exprMapTarget.Parameters[0], right, op, gMap.Convertor, false, gMap.CaseInsensitive);
                if (exprQuery == null) continue;
 
                if (exprHasIndexer)
@@ -193,7 +193,7 @@ public abstract class BaseQueryBuilder<TQuery, T>(IGridifyMapper<T> mapper)
          return (result, isNested);
       }
 
-      var query = BuildQuery(mapTarget.Body, mapTarget.Parameters[0], right, op, gMap.Convertor, false);
+      var query = BuildQuery(mapTarget.Body, mapTarget.Parameters[0], right, op, gMap.Convertor, false, gMap.CaseInsensitive);
       if (query == null) return null;
 
       if (hasIndexer)
@@ -264,7 +264,8 @@ public abstract class BaseQueryBuilder<TQuery, T>(IGridifyMapper<T> mapper)
       ValueExpressionSyntax valueExpression,
       ISyntaxNode op,
       Func<string, object>? convertor,
-      bool isNested)
+      bool isNested,
+      bool? mapCaseInsensitive)
    {
       // Remove the boxing for value types
       if (body.NodeType == ExpressionType.Convert) body = ((UnaryExpression)body).Operand;
@@ -320,8 +321,11 @@ public abstract class BaseQueryBuilder<TQuery, T>(IGridifyMapper<T> mapper)
       }
 
       // handle case-Insensitive search
-      if (value is not null && body.Type == typeof(string) && (valueExpression.IsCaseInsensitive
-                            || mapper.Configuration.CaseInsensitiveFiltering)
+      // mapCaseInsensitive overrides the global mapper config per-map: true=force insensitive, false=force sensitive, null=use config
+      var isCaseInsensitive = valueExpression.IsCaseInsensitive
+                              || mapCaseInsensitive == true
+                              || (mapCaseInsensitive == null && mapper.Configuration.CaseInsensitiveFiltering);
+      if (value is not null && body.Type == typeof(string) && isCaseInsensitive
                             && op.Kind is not SyntaxKind.GreaterThan
                             && op.Kind is not SyntaxKind.LessThan
                             && op.Kind is not SyntaxKind.GreaterOrEqualThan

--- a/src/Gridify/Builder/LinqQueryBuilder.cs
+++ b/src/Gridify/Builder/LinqQueryBuilder.cs
@@ -30,7 +30,8 @@ public class LinqQueryBuilder<T> : BaseQueryBuilder<Expression<Func<T, bool>>, T
                   value,
                   op,
                   gMap.Convertor,
-                  true);
+                  true,
+                  gMap.CaseInsensitive);
 
                if (conditionExp is not LambdaExpression lambdaExp) return null;
 
@@ -272,7 +273,7 @@ public class LinqQueryBuilder<T> : BaseQueryBuilder<Expression<Func<T, bool>>, T
             case MethodCallExpression { Method.Name: "Select" } selectExp:
             {
                var targetExp = selectExp.Arguments.Single(a => a.NodeType == ExpressionType.Lambda) as LambdaExpression;
-               var conditionExp = BuildQuery(targetExp!.Body, targetExp.Parameters[0], value, op, gMap.Convertor, true);
+               var conditionExp = BuildQuery(targetExp!.Body, targetExp.Parameters[0], value, op, gMap.Convertor, true, gMap.CaseInsensitive);
 
                if (conditionExp is not LambdaExpression lambdaExp) return null;
 

--- a/src/Gridify/Builder/LinqQueryBuilder.cs
+++ b/src/Gridify/Builder/LinqQueryBuilder.cs
@@ -31,7 +31,7 @@ public class LinqQueryBuilder<T> : BaseQueryBuilder<Expression<Func<T, bool>>, T
                   op,
                   gMap.Convertor,
                   true,
-                  gMap.CaseInsensitive ?? value.IsCaseInsensitive);
+                  gMap.CaseInsensitive);
 
                if (conditionExp is not LambdaExpression lambdaExp) return null;
 

--- a/src/Gridify/Builder/LinqQueryBuilder.cs
+++ b/src/Gridify/Builder/LinqQueryBuilder.cs
@@ -31,7 +31,7 @@ public class LinqQueryBuilder<T> : BaseQueryBuilder<Expression<Func<T, bool>>, T
                   op,
                   gMap.Convertor,
                   true,
-                  gMap.CaseInsensitive);
+                  gMap.CaseInsensitive ?? value.IsCaseInsensitive);
 
                if (conditionExp is not LambdaExpression lambdaExp) return null;
 

--- a/src/Gridify/CompositeGMap.cs
+++ b/src/Gridify/CompositeGMap.cs
@@ -14,6 +14,7 @@ public class CompositeGMap<T> : IGMap<T>
    public string From { get; set; }
    public LambdaExpression To { get; set; }
    public Func<string, object>? Convertor { get; set; }
+   public bool? CaseInsensitive { get; set; }
 
    /// <summary>
    /// Collection of expressions that will be combined with OR logic

--- a/src/Gridify/GMap.cs
+++ b/src/Gridify/GMap.cs
@@ -9,6 +9,7 @@ public partial class GMap<T> : IGMap<T>
    public string From { get; set; }
    public LambdaExpression To { get; set; }
    public Func<string, object>? Convertor { get; set; }
+   public bool? CaseInsensitive { get; set; }
 
    public GMap(string from, Expression<Func<T, object?>> to, Func<string, object>? convertor = null)
    {

--- a/src/Gridify/GridifyMapper.cs
+++ b/src/Gridify/GridifyMapper.cs
@@ -41,7 +41,7 @@ public class GridifyMapper<T> : IGridifyMapper<T>
          GenerateMappings();
    }
 
-   public IGridifyMapper<T> AddMap(string from, Func<string, object>? convertor = null!, bool overrideIfExists = true)
+   public IGridifyMapper<T> AddMap(string from, Func<string, object>? convertor = null!, bool overrideIfExists = true, bool? caseInsensitive = null)
    {
       if (!overrideIfExists && HasMap(from))
          throw new GridifyMapperException($"Duplicate Key. the '{from}' key already exists");
@@ -57,7 +57,7 @@ public class GridifyMapper<T> : IGridifyMapper<T>
       }
 
       RemoveMap(from);
-      _mappings.Add(new GMap<T>(from, to!, convertor));
+      _mappings.Add(new GMap<T>(from, to!, convertor) { CaseInsensitive = caseInsensitive });
       return this;
    }
 
@@ -105,13 +105,13 @@ public class GridifyMapper<T> : IGridifyMapper<T>
    }
 
    public IGridifyMapper<T> AddMap(string from, Expression<Func<T, object?>> to, Func<string, object>? convertor = null!,
-      bool overrideIfExists = true)
+      bool overrideIfExists = true, bool? caseInsensitive = null)
    {
       if (!overrideIfExists && HasMap(from))
          throw new GridifyMapperException($"Duplicate Key. the '{from}' key already exists");
 
       RemoveMap(from);
-      _mappings.Add(new GMap<T>(from, to, convertor));
+      _mappings.Add(new GMap<T>(from, to, convertor) { CaseInsensitive = caseInsensitive });
       return this;
    }
 

--- a/src/Gridify/IGMap.cs
+++ b/src/Gridify/IGMap.cs
@@ -8,4 +8,6 @@ public interface IGMap<T>
    string From { get; set; }
    LambdaExpression To { get; set; }
    Func<string, object>? Convertor { get; set; }
+   // null = use global config, true = force case-insensitive, false = force case-sensitive
+   bool? CaseInsensitive { get; set; }
 }

--- a/src/Gridify/IGridifyMapper.cs
+++ b/src/Gridify/IGridifyMapper.cs
@@ -6,7 +6,7 @@ namespace Gridify;
 
 public interface IGridifyMapper<T>
 {
-   IGridifyMapper<T> AddMap(string from, Expression<Func<T, object?>> to, Func<string, object>? convertor = null, bool overrideIfExists = true);
+   IGridifyMapper<T> AddMap(string from, Expression<Func<T, object?>> to, Func<string, object>? convertor = null, bool overrideIfExists = true, bool? caseInsensitive = null);
 
    IGridifyMapper<T> AddMap(string from, Expression<Func<T, int, object?>> to, Func<string, object>? convertor = null!,
       bool overrideIfExists = true);
@@ -16,7 +16,7 @@ public interface IGridifyMapper<T>
       bool overrideIfExists = true);
 
    IGridifyMapper<T> AddMap(IGMap<T> gMap, bool overrideIfExists = true);
-   IGridifyMapper<T> AddMap(string from, Func<string, object>? convertor = null!, bool overrideIfExists = true);
+   IGridifyMapper<T> AddMap(string from, Func<string, object>? convertor = null!, bool overrideIfExists = true, bool? caseInsensitive = null);
 
    /// <summary>
    /// Adds a composite mapping that combines multiple property expressions with OR logic.

--- a/test/Gridify.Tests/IssueTests/CaseInsensitivePerMapTests.cs
+++ b/test/Gridify.Tests/IssueTests/CaseInsensitivePerMapTests.cs
@@ -12,7 +12,7 @@ public class CaseInsensitivePerMapTests
       new TestClass { Name = "Bob",   Tags = ["Python", "Django"] },
    };
 
-   // --- string field: caseSensitive=true overrides global CaseInsensitiveFiltering=true ---
+   // --- string field: caseInsensitive=false overrides global CaseInsensitiveFiltering=true ---
 
    [Fact]
    public void AddMap_CaseSensitiveTrue_OnStringField_ShouldNotMatchWrongCase()
@@ -32,7 +32,7 @@ public class CaseInsensitivePerMapTests
       Assert.Single(DataSource.AsQueryable().ApplyFiltering("Name=Alice", mapper).ToList());
    }
 
-   // --- string field: caseSensitive=false overrides global CaseInsensitiveFiltering=false ---
+   // --- string field: caseInsensitive=true overrides global CaseInsensitiveFiltering=false ---
 
    [Fact]
    public void AddMap_CaseSensitiveFalse_OnStringField_ShouldMatchWrongCaseWhenGlobalIsOff()
@@ -43,7 +43,7 @@ public class CaseInsensitivePerMapTests
       Assert.Single(DataSource.AsQueryable().ApplyFiltering("Name=alice", mapper).ToList());
    }
 
-   // --- List<string> field: use the (string, convertor, caseSensitive) overload so CreateExpression
+   // --- List<string> field: use the (string, convertor, caseInsensitive) overload so CreateExpression
    //     auto-wraps the collection with .Select(fc => fc), making IsNestedCollection() true ---
 
    [Fact]

--- a/test/Gridify.Tests/IssueTests/CaseInsensitivePerMapTests.cs
+++ b/test/Gridify.Tests/IssueTests/CaseInsensitivePerMapTests.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Gridify.Tests.IssueTests;
+
+public class CaseInsensitivePerMapTests
+{
+   private List<TestClass> DataSource => new()
+   {
+      new TestClass { Name = "Alice", Tags = ["CSharp", "DotNet"] },
+      new TestClass { Name = "Bob",   Tags = ["Python", "Django"] },
+   };
+
+   // --- string field: caseSensitive=true overrides global CaseInsensitiveFiltering=true ---
+
+   [Fact]
+   public void AddMap_CaseSensitiveTrue_OnStringField_ShouldNotMatchWrongCase()
+   {
+      var mapper = new GridifyMapper<TestClass>(c => c.CaseInsensitiveFiltering = true)
+         .AddMap("Name", x => x.Name, caseInsensitive: false);
+
+      Assert.Empty(DataSource.AsQueryable().ApplyFiltering("Name=alice", mapper).ToList());
+   }
+
+   [Fact]
+   public void AddMap_CaseSensitiveTrue_OnStringField_ShouldMatchCorrectCase()
+   {
+      var mapper = new GridifyMapper<TestClass>(c => c.CaseInsensitiveFiltering = true)
+         .AddMap("Name", x => x.Name, caseInsensitive: false);
+
+      Assert.Single(DataSource.AsQueryable().ApplyFiltering("Name=Alice", mapper).ToList());
+   }
+
+   // --- string field: caseSensitive=false overrides global CaseInsensitiveFiltering=false ---
+
+   [Fact]
+   public void AddMap_CaseSensitiveFalse_OnStringField_ShouldMatchWrongCaseWhenGlobalIsOff()
+   {
+      var mapper = new GridifyMapper<TestClass>(c => c.CaseInsensitiveFiltering = false)
+         .AddMap("Name", x => x.Name, caseInsensitive: true);
+
+      Assert.Single(DataSource.AsQueryable().ApplyFiltering("Name=alice", mapper).ToList());
+   }
+
+   // --- List<string> field: use the (string, convertor, caseSensitive) overload so CreateExpression
+   //     auto-wraps the collection with .Select(fc => fc), making IsNestedCollection() true ---
+
+   [Fact]
+   public void AddMap_CaseSensitiveTrue_OnListOfStrings_ShouldNotMatchWrongCase()
+   {
+      var mapper = new GridifyMapper<TestClass>(c => c.CaseInsensitiveFiltering = true)
+         .AddMap("Tags", caseInsensitive: false);
+
+      Assert.Empty(DataSource.AsQueryable().ApplyFiltering("Tags=csharp", mapper).ToList());
+   }
+
+   [Fact]
+   public void AddMap_CaseSensitiveTrue_OnListOfStrings_ShouldMatchCorrectCase()
+   {
+      var mapper = new GridifyMapper<TestClass>(c => c.CaseInsensitiveFiltering = true)
+         .AddMap("Tags", caseInsensitive: false);
+
+      Assert.Single(DataSource.AsQueryable().ApplyFiltering("Tags=CSharp", mapper).ToList());
+   }
+
+   [Fact]
+   public void AddMap_CaseSensitiveFalse_OnListOfStrings_ShouldMatchWrongCaseWhenGlobalIsOff()
+   {
+      var mapper = new GridifyMapper<TestClass>(c => c.CaseInsensitiveFiltering = false)
+         .AddMap("Tags", caseInsensitive: true);
+
+      Assert.Single(DataSource.AsQueryable().ApplyFiltering("Tags=csharp", mapper).ToList());
+   }
+
+   private class TestClass
+   {
+      public string Name { get; set; } = "";
+      public List<string> Tags { get; set; } = [];
+   }
+}


### PR DESCRIPTION
# Description

I am working with some large tables with a lot of columns, I have had to specifically decide which columns a user should be allowed to query in a case-insensitive manner. We do not want the user to have to enter /i in the queries. 

Some columns in our case are needed to be Case-Sensitive for performance reasons. Exact strings matching is much faster in postgres and in clickhouse with large data. Than case-insensitive matching. 


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
